### PR TITLE
Release/1.0.1

### DIFF
--- a/PushAndPull/Server/Application/Port/Output/Persistence/IUserRepository.cs
+++ b/PushAndPull/Server/Application/Port/Output/Persistence/IUserRepository.cs
@@ -6,7 +6,6 @@ namespace Server.Application.Port.Output.Persistence
     {
         Task<User?> GetBySteamIdAsync(ulong steamId, CancellationToken ct = default);
         Task CreateAsync(User user, CancellationToken ct = default);
-        Task UpdateNicknameAsync(ulong steamId, string newNickname, CancellationToken ct = default);
-        Task UpdateLastLoginAsync(ulong steamId, DateTime lastLoginAt, CancellationToken ct = default);
+        Task UpdateAsync(ulong steamId, string nickname, DateTime lastLoginAt, CancellationToken ct = default);
     }
 }

--- a/PushAndPull/Server/Application/UseCase/Auth/LoginUseCase.cs
+++ b/PushAndPull/Server/Application/UseCase/Auth/LoginUseCase.cs
@@ -34,12 +34,7 @@ public class LoginUseCase : ILoginUseCase
         }
         else
         {
-            if (user.Nickname != request.Nickname)
-            {
-                await _userRepository.UpdateNicknameAsync(user.SteamId, request.Nickname);
-            }
-
-            await _userRepository.UpdateLastLoginAsync(user.SteamId, DateTime.UtcNow);
+            await _userRepository.UpdateAsync(user.SteamId, request.Nickname, DateTime.UtcNow);
         }
 
         var session = await _sessionService.CreateAsync(

--- a/PushAndPull/Server/Infrastructure/Persistence/Repository/UserRepository.cs
+++ b/PushAndPull/Server/Infrastructure/Persistence/Repository/UserRepository.cs
@@ -27,23 +27,13 @@ public class UserRepository : IUserRepository
         await _context.SaveChangesAsync(ct);
     }
 
-    public async Task UpdateNicknameAsync(ulong steamId, string newNickname, CancellationToken ct = default)
+    public async Task UpdateAsync(ulong steamId, string nickname, DateTime lastLoginAt, CancellationToken ct = default)
     {
-        var user = await _context.Users.FirstOrDefaultAsync(u => u.SteamId == steamId, ct);
-        if (user != null)
-        {
-            user.Nickname = newNickname;
-            await _context.SaveChangesAsync(ct);
-        }
-    }
-
-    public async Task UpdateLastLoginAsync(ulong steamId, DateTime lastLoginAt, CancellationToken ct = default)
-    {
-        var user = await _context.Users.FirstOrDefaultAsync(u => u.SteamId == steamId, ct);
-        if (user != null)
-        {
-            user.LastLoginAt = lastLoginAt;
-            await _context.SaveChangesAsync(ct);
-        }
+        await _context.Users
+            .Where(u => u.SteamId == steamId)
+            .ExecuteUpdateAsync(s => s
+                    .SetProperty(u => u.Nickname, nickname)
+                    .SetProperty(u => u.LastLoginAt, lastLoginAt),
+                ct);
     }
 }

--- a/PushAndPull/Server/Program.cs
+++ b/PushAndPull/Server/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddScoped<ISessionService, SessionService>();
 builder.Services.AddScoped<ILoginUseCase, LoginUseCase>();
 builder.Services.AddScoped<ILogoutUseCase, LogoutUseCase>();
 
+builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IRoomRepository, RoomRepository>();
 
 builder.Services.AddSingleton<IRoomCodeGenerator, RoomCodeGenerator>();

--- a/PushAndPull/Server/Server.csproj
+++ b/PushAndPull/Server/Server.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.17.1" />
-        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+        <PackageReference Include="Azure.Identity" Version="1.18.0" />
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />


### PR DESCRIPTION
## 📚작업 내용
= `UpdateNicknameAsync`와 `UpdateLastLoginAsync`를 `UpdateUserAsync` 하나로 통합했습니다.

**변경 사항**
- `IUserRepository`에 `UpdateUserAsync` 메서드 추가
- `UserRepository`에 `ExecuteUpdateAsync` 방식으로 구현
- `UpdateNicknameAsync`, `UpdateLastLoginAsync` 제거
- `LoginUseCase`에서 `UpdateUserAsync` 단일 호출로 변경

## ◀️참고 사항
> 기존 2번의 DB 쿼리에서 1번의 UPDATE 쿼리로 개선되었습니다.

## ✅체크리스트
- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 이 포함되어 있지 않나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?