### PR TITLE
fix: Key Vault 연동 방식을 AddAzureKeyVault으로 변경

### DIFF
--- a/PushAndPull/Server/Program.cs
+++ b/PushAndPull/Server/Program.cs
@@ -1,5 +1,4 @@
 using Azure.Identity;
-using Azure.Security.KeyVault.Secrets;
 using Microsoft.EntityFrameworkCore;
 using Server.Application.Port.Input;
 using Server.Application.Port.Output;
@@ -17,13 +16,10 @@ using StackExchange.Redis;
 var builder = WebApplication.CreateBuilder(args);
 
 var keyVaultUri = new Uri(builder.Configuration["KeyVault:Uri"]!);
-var secretName = builder.Configuration["KeyVault:DbConnectionSecretName"]!;
+builder.Configuration.AddAzureKeyVault(keyVaultUri, new DefaultAzureCredential());
 
-var credential = new DefaultAzureCredential();
-var secretClient = new SecretClient(keyVaultUri, credential);
-
-KeyVaultSecret secret = await secretClient.GetSecretAsync(secretName);
-string connectionString = secret.Value;
+var connectionString = builder.Configuration[builder.Configuration["KeyVault:DbConnectionSecretName"]!]
+                       ?? throw new InvalidOperationException("DB 연결 문자열을 Key Vault에서 가져올 수 없습니다.");
 
 builder.Services.AddControllers();
 
@@ -33,7 +29,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 });
 
 builder.Services.AddSingleton<IConnectionMultiplexer>(_ =>
-{
+{   
     var connStr = builder.Configuration["Redis:ConnectionString"]
                   ?? throw new InvalidOperationException();
     return ConnectionMultiplexer.Connect(connStr);

--- a/PushAndPull/Server/Server.csproj
+++ b/PushAndPull/Server/Server.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.0" />
         <PackageReference Include="Azure.Identity" Version="1.18.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />


### PR DESCRIPTION
#10

## 📚작업 내용

- Program.cs의 Key Vault 연동 방식을 리팩토링했습니다.

> **변경 전:** `SecretClient`를 직접 호출하여 시크릿을 가져오는 방식
> ```csharp
> var secretClient = new SecretClient(keyVaultUri, credential);
> KeyVaultSecret secret = await secretClient.GetSecretAsync(secretName);
> string connectionString = secret.Value;
> ```
> **변경 후:** `AddAzureKeyVault` Configuration Provider 방식
> ```csharp
> builder.Configuration.AddAzureKeyVault(keyVaultUri, new DefaultAzureCredential());
> var connectionString = builder.Configuration["dbconnection-prod"];
> ```

## ◀️참고 사항

- 기존 방식은 앱 시작 시 Key Vault 호출이 실패(권한 전파 지연 등)하면 앱 전체가 크래시되는 문제가 있었습니다.
- `Azure.Extensions.AspNetCore.Configuration.Secrets` 패키지 추가 필요합니다.


## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?

 
> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
