### PR TITLE
fix: JoinRoom 비밀번호 검증 조건 및 응답 형식 개선

### DIFF
--- a/PushAndPull/.claude/settings.local.json
+++ b/PushAndPull/.claude/settings.local.json
@@ -26,7 +26,8 @@
       "Skill(commit)",
       "Skill(db-migrate)",
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Skill(pr)"
     ]
   }
 }

--- a/PushAndPull/.claude/skills/pr/SKILL.md
+++ b/PushAndPull/.claude/skills/pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr
 description: Generates a PR title suggestion and body based on the current branch, then creates a GitHub PR. Supports develop/release/feature branches.
-allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(git tag:*), Bash(git checkout:*), Bash(gh pr create:*), Bash(rm:*), Write, AskUserQuestion
+allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(git tag:*), Bash(git checkout:*), Bash(gh pr create:*), Bash(rm:*), Write, Read, AskUserQuestion
 context: fork
 ---
 
@@ -114,20 +114,15 @@ rm PR_BODY.md
 
 **Step 4. Output** in this format:
 ```
-## 추천 PR 제목
-
-1. [title1]
-2. [title2]
-3. [title3]
-
 ## PR 본문 (PR_BODY.md에 저장됨)
 
 [full body preview]
 ```
 
-**Step 5. Ask the user** using AskUserQuestion with a `choices` array:
-- Options: the 3 generated titles + "직접 입력" as the last option
-- If the user selects "직접 입력", ask a follow-up AskUserQuestion for the custom title
+**Step 5. Ask the user** using AskUserQuestion — you MUST call this tool, do NOT print a text prompt:
+- `question`: "PR 제목을 선택해주세요."
+- `choices`: the 3 generated titles + "직접 입력" as the last option
+- If the user selects "직접 입력", immediately call AskUserQuestion again with `question`: "PR 제목을 입력해주세요."
 
 **Step 6. Create PR to `{Base Branch}`**
 

--- a/PushAndPull/PushAndPull.Test/Service/Room/JoinRoomServiceTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Room/JoinRoomServiceTests.cs
@@ -63,6 +63,35 @@ public class JoinRoomServiceTests
         }
     }
 
+    public class WhenAPrivateRoomIsJoinedWithoutAPassword
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly Mock<IPasswordHasher> _passwordHasherMock = new();
+        private readonly JoinRoomService _sut;
+
+        private const string RoomCode = "PRIV02";
+
+        public WhenAPrivateRoomIsJoinedWithoutAPassword()
+        {
+            var privateRoom = new EntityRoom(RoomCode, "Private Room", 222UL, 76561198000000001UL, true, "some-hash");
+
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode))
+                .ReturnsAsync(privateRoom);
+
+            _sut = new JoinRoomService(_roomRepositoryMock.Object, _passwordHasherMock.Object);
+        }
+
+        [Fact]
+        public async Task It_ThrowsInvalidOperationExceptionWithPasswordRequiredMessage()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _sut.ExecuteAsync(new JoinRoomCommand(RoomCode, null)));
+
+            Assert.Equal("PASSWORD_REQUIRED", ex.Message);
+        }
+    }
+
     public class WhenTheWrongPasswordIsProvidedForAPrivateRoom
     {
         private readonly Mock<IRoomRepository> _roomRepositoryMock = new();

--- a/PushAndPull/PushAndPull/Domain/Auth/Controller/AuthController.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Controller/AuthController.cs
@@ -24,27 +24,26 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("login")]
-    public async Task<LoginResponse> Login(
+    public async Task<CommonApiResponse<LoginResponse>> Login(
         [FromBody] LoginRequest request
         )
     {
         var result = await _loginService.ExecuteAsync(new LoginCommand(
             request.SteamTicket,
             request.Nickname
-            )
-        );
+        ));
 
-        return new LoginResponse(result.SessionId);
+        return CommonApiResponse.Success("로그인되었습니다.", new LoginResponse(result.SessionId));
     }
 
     [SessionAuthorize]
     [HttpPost("logout")]
-    public async Task Logout()
+    public async Task<CommonApiResponse> Logout()
     {
         var sessionId = User.GetSessionId();
 
-        await _logoutService.ExecuteAsync(
-            new LogoutCommand(sessionId)
-        );
+        await _logoutService.ExecuteAsync(new LogoutCommand(sessionId));
+
+        return CommonApiResponse.Success("로그아웃되었습니다.");
     }
 }

--- a/PushAndPull/PushAndPull/Domain/Auth/Repository/UserRepository.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Repository/UserRepository.cs
@@ -23,17 +23,8 @@ public class UserRepository : IUserRepository
 
     public async Task CreateAsync(User user, CancellationToken ct = default)
     {
-        await _context.Database.ExecuteSqlRawAsync(
-            """
-            INSERT INTO game_user."user" (steam_id, nickname, created_at, last_login_at)
-            VALUES ({0}, {1}, {2}, {3})
-            ON CONFLICT (steam_id) DO UPDATE
-            SET nickname = EXCLUDED.nickname,
-                last_login_at = EXCLUDED.last_login_at
-            """,
-            [user.SteamId, user.Nickname, user.CreatedAt, user.LastLoginAt],
-            ct
-        );
+        await _context.Users.AddAsync(user, ct);
+        await _context.SaveChangesAsync(ct);
     }
 
     public async Task UpdateAsync(ulong steamId, string nickname, DateTime lastLoginAt, CancellationToken ct = default)

--- a/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
@@ -43,54 +43,43 @@ public class RoomController : ControllerBase
             request.IsPrivate,
             request.Password,
             hostSteamId
-            )
-        );
+        ));
 
         return CommonApiResponse.Created("방이 생성되었습니다.", new CreateRoomResponse(result.RoomCode));
     }
 
     [HttpGet("{roomCode}")]
-    public async Task<GetRoomResponse> GetRoom(
+    public async Task<CommonApiResponse<GetRoomResponse>> GetRoom(
         [FromRoute] string roomCode
     )
     {
-        var result = await _getRoomService.ExecuteAsync(
-            new GetRoomCommand(roomCode)
-        );
+        var result = await _getRoomService.ExecuteAsync(new GetRoomCommand(roomCode));
 
-        return new GetRoomResponse(
+        return CommonApiResponse.Success("방 조회 성공.", new GetRoomResponse(
             result.RoomCode,
             result.RoomName,
             result.CurrentPlayers,
             result.IsPrivate
-        );
+        ));
     }
 
     [HttpGet("all")]
-    public async Task<GetAllRoomResponse> GetAllRoom(CancellationToken ct)
+    public async Task<CommonApiResponse<GetAllRoomResponse>> GetAllRoom(CancellationToken ct)
     {
         var result = await _getAllRoomService.ExecuteAsync(ct);
 
-        return new GetAllRoomResponse(
-            result.Rooms.Select(r => new GetRoomResponse(
-                r.RoomCode,
-                r.RoomName,
-                r.CurrentPlayers,
-                r.IsPrivate
-            )).ToList()
-        );
+        return CommonApiResponse.Success("방 목록 조회 성공.", new GetAllRoomResponse(result.Rooms));
     }
 
     [SessionAuthorize]
     [HttpPost("{roomCode}/join")]
-    public async Task JoinRoom(
+    public async Task<CommonApiResponse> JoinRoom(
         [FromRoute] string roomCode,
         [FromBody] JoinRoomRequest request
         )
     {
-        await _joinRoomService.ExecuteAsync(new JoinRoomCommand(
-            roomCode,
-            request.Password)
-        );
+        await _joinRoomService.ExecuteAsync(new JoinRoomCommand(roomCode, request.Password));
+
+        return CommonApiResponse.Success("방에 참여했습니다.");
     }
 }

--- a/PushAndPull/PushAndPull/Domain/Room/Entity/Room.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Entity/Room.cs
@@ -22,6 +22,8 @@ public class Room
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset? ExpiresAt { get; set; }
 
+    private const int DefaultMaxPlayers = 2;
+
     protected Room() { }
 
     public Room(
@@ -38,7 +40,7 @@ public class Room
         SteamLobbyId = steamLobbyId;
         HostSteamId = hostSteamId;
         CurrentPlayers = 1;
-        MaxPlayers = 2;
+        MaxPlayers = DefaultMaxPlayers;
         IsPrivate = isPrivate;
         PasswordHash = passwordHash;
         Status = RoomStatus.Active;

--- a/PushAndPull/PushAndPull/Domain/Room/Service/GetAllRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/GetAllRoomService.cs
@@ -1,3 +1,4 @@
+using PushAndPull.Domain.Room.Dto.Response;
 using PushAndPull.Domain.Room.Repository.Interface;
 using PushAndPull.Domain.Room.Service.Interface;
 
@@ -16,15 +17,15 @@ public class GetAllRoomService : IGetAllRoomService
     {
         var rooms = await _roomRepository.GetAllAsync(ct);
 
-        var summaries = rooms
-            .Select(room => new RoomSummary(
-                room.RoomName,
+        var responses = rooms
+            .Select(room => new GetRoomResponse(
                 room.RoomCode,
+                room.RoomName,
                 room.CurrentPlayers,
                 room.IsPrivate
             ))
             .ToList();
 
-        return new GetAllRoomResult(summaries);
+        return new GetAllRoomResult(responses);
     }
 }

--- a/PushAndPull/PushAndPull/Domain/Room/Service/Interface/IGetAllRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/Interface/IGetAllRoomService.cs
@@ -1,3 +1,5 @@
+using PushAndPull.Domain.Room.Dto.Response;
+
 namespace PushAndPull.Domain.Room.Service.Interface;
 
 public interface IGetAllRoomService
@@ -6,5 +8,5 @@ public interface IGetAllRoomService
 }
 
 public record GetAllRoomResult(
-    IReadOnlyList<RoomSummary> Rooms
-        );
+    IReadOnlyList<GetRoomResponse> Rooms
+);

--- a/PushAndPull/PushAndPull/Domain/Room/Service/JoinRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/JoinRoomService.cs
@@ -30,7 +30,7 @@ public class JoinRoomService : IJoinRoomService
 
         if (room.IsPrivate)
         {
-            if (request.Password == null)
+            if (string.IsNullOrWhiteSpace(request.Password))
                 throw new InvalidOperationException("PASSWORD_REQUIRED");
 
             if (!_passwordHasher.Verify(request.Password, room.PasswordHash!))

--- a/PushAndPull/PushAndPull/Domain/Room/Service/JoinRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/JoinRoomService.cs
@@ -28,12 +28,12 @@ public class JoinRoomService : IJoinRoomService
         if (room.Status != RoomStatus.Active)
             throw new RoomNotActiveException(request.RoomCode);
 
-        if (request.Password != null)
+        if (room.IsPrivate)
         {
-            if (string.IsNullOrWhiteSpace(request.Password))
+            if (request.Password == null)
                 throw new InvalidOperationException("PASSWORD_REQUIRED");
 
-            if (!_passwordHasher.Verify( request.Password, room.PasswordHash!))
+            if (!_passwordHasher.Verify(request.Password, room.PasswordHash!))
                 throw new InvalidOperationException("INVALID_PASSWORD");
         }
 

--- a/PushAndPull/PushAndPull/Domain/Room/Service/RoomSummary.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/RoomSummary.cs
@@ -1,8 +1,0 @@
-namespace PushAndPull.Domain.Room.Service;
-
-public record RoomSummary(
-    string RoomName,
-    string RoomCode,
-    int CurrentPlayers,
-    bool IsPrivate
-    );


### PR DESCRIPTION
## 📚작업 내용

- `JoinRoomService` 비밀번호 검증 조건을 `request.Password != null`에서 `room.IsPrivate` 기준으로 수정 (공개 방에 비밀번호 전달 시 잘못된 검증 실행되던 버그 수정)
- Auth 컨트롤러 Login, Logout 응답 형식을 `CommonApiResponse`로 통일
- Room 컨트롤러 GetRoom, GetAllRoom, JoinRoom 응답 형식을 `CommonApiResponse`로 통일
- `RoomSummary` 레코드 제거 — `GetRoomResponse`로 대체하여 중복 타입 제거
- `UserRepository.CreateAsync`를 Raw SQL에서 EF Core `AddAsync`로 교체
- `Room` 엔터티 최대 플레이어 수를 `DefaultMaxPlayers` 상수로 추출
- 비공개 방에 비밀번호 없이 참여 시 예외를 검증하는 테스트 케이스 추가

## ◀️참고 사항

비밀번호 검증 버그: 기존 로직은 요청에 비밀번호가 포함된 경우에만 검증을 수행해 공개 방에도 비밀번호를 전달하면 검증이 실행되는 문제가 있었습니다. `room.IsPrivate` 기준으로 변경하여 비공개 방에서만 검증이 동작하도록 수정했습니다.

## ✅체크리스트

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?