### PR TITLE
chore: Docker Compose 기반 배포 파이프라인 구성

### DIFF
--- a/.github/workflows/Deploy-Server.yaml
+++ b/.github/workflows/Deploy-Server.yaml
@@ -23,7 +23,18 @@ jobs:
     - name: Push Docker image
       run: docker push seanyee1227/pushandpull-server:latest
 
-    - name: Deploy to server via SSH
+    - name: Copy compose file to server
+      uses: appleboy/scp-action@v0.1.7
+      with:
+        host: ${{ secrets.SSH_HOST }}
+        username: ${{ secrets.SSH_USERNAME }}
+        port: ${{ secrets.SSH_PORT }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        source: "PushAndPull/deploy/compose.prod.yaml"
+        target: "~/deploy/"
+        strip_components: 2
+
+    - name: Deploy via Docker Compose
       uses: appleboy/ssh-action@v0.1.10
       with:
         host: ${{ secrets.SSH_HOST }}
@@ -31,18 +42,17 @@ jobs:
         port: ${{ secrets.SSH_PORT }}
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         script: |
-          docker pull seanyee1227/pushandpull-server:latest
-          docker stop pushandpull-server || true
-          docker rm pushandpull-server || true
-          docker run -d \
-            --name pushandpull-server \
-            --restart unless-stopped \
-            -p 21754:80 \
-            -e ASPNETCORE_URLS=http://+:80 \
-            -e ASPNETCORE_ENVIRONMENT=Production \
-            -e "ConnectionStrings__Default=${{ secrets.DB_CONNECTION_STRING }}" \
-            seanyee1227/pushandpull-server:latest
+          mkdir -p ~/deploy
+
+          printf 'DB_CONNECTION_STRING=%s\nREDIS_CONNECTION_STRING=%s\nSTEAM_WEB_API_KEY=%s\n' \
+            "${{ secrets.DB_CONNECTION_STRING }}" \
+            "${{ secrets.REDIS_CONNECTION_STRING }}" \
+            "${{ secrets.STEAM_WEB_API_KEY }}" \
+            > ~/deploy/.env
+
+          docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env pull
+          docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env up -d
 
           sleep 5
-          docker ps | grep pushandpull-server
-          docker logs pushandpull-server --tail 20
+          docker ps | grep pushpull-server
+          docker logs pushpull-server --tail 20

--- a/.github/workflows/Deploy-Server.yaml
+++ b/.github/workflows/Deploy-Server.yaml
@@ -54,5 +54,5 @@ jobs:
           docker compose -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env up -d
 
           sleep 5
-          docker ps | grep pushpull-server
-          docker logs pushpull-server --tail 20
+          docker ps | grep pushandpull-server
+          docker logs pushandpull-server --tail 20

--- a/PushAndPull/PushAndPull/appsettings.Production.json
+++ b/PushAndPull/PushAndPull/appsettings.Production.json
@@ -10,7 +10,7 @@
     "AppId": 480
   },
   "Redis": {
-    "ConnectionString": "127.0.0.1:6379,abortConnect=false"
+    "ConnectionString": ""
   },
   "ConnectionStrings": {
     "Default": ""

--- a/PushAndPull/PushAndPull/appsettings.json
+++ b/PushAndPull/PushAndPull/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "Steam": {
-    "WebApiKey": "Steam-ApiKey",
+    "WebApiKey": "",
     "AppId": 480
   },
   "ConnectionStrings": {

--- a/PushAndPull/deploy/compose.prod.yaml
+++ b/PushAndPull/deploy/compose.prod.yaml
@@ -1,25 +1,16 @@
 name: pushandpull-prod
 
 services:
-  pushpull-db:
-    image: postgres:17
-    container_name: pushpull-db
-    environment:
-      POSTGRES_DB: pushpull
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    restart: unless-stopped
-
-  pushpull-redis:
+  pushandpull-redis:
     image: redis:7-alpine
-    container_name: pushpull-redis
+    container_name: pushandpull-redis
     volumes:
       - redis_data:/data
+    networks:
+      - pushandpull-network
     restart: unless-stopped
 
-  pushpull-server:
+  pushandpull-server:
     image: seanyee1227/pushandpull-server:latest
     container_name: pushpull-server
     ports:
@@ -29,12 +20,16 @@ services:
       - ASPNETCORE_URLS=http://+:80
       - ConnectionStrings__Default=${DB_CONNECTION_STRING}
       - Redis__ConnectionString=${REDIS_CONNECTION_STRING}
-      - Steam__WebApiKey=${STEAM_WEB_API_KEY}
+      - Steam__WebApiKey=${STEAM_API_KEY}
     depends_on:
-      - pushpull-db
-      - pushpull-redis
+      - pushandpull-redis
+    networks:
+      - pushandpull-network
     restart: unless-stopped
 
 volumes:
-  postgres_data:
   redis_data:
+
+networks:
+  pushandpull-network:
+    driver: bridge

--- a/PushAndPull/deploy/compose.prod.yaml
+++ b/PushAndPull/deploy/compose.prod.yaml
@@ -20,7 +20,7 @@ services:
       - ASPNETCORE_URLS=http://+:80
       - ConnectionStrings__Default=${DB_CONNECTION_STRING}
       - Redis__ConnectionString=${REDIS_CONNECTION_STRING}
-      - Steam__WebApiKey=${STEAM_API_KEY}
+      - Steam__WebApiKey=${STEAM_WEB_API_KEY}
     depends_on:
       - pushandpull-redis
     networks:

--- a/PushAndPull/deploy/compose.prod.yaml
+++ b/PushAndPull/deploy/compose.prod.yaml
@@ -12,7 +12,7 @@ services:
 
   pushandpull-server:
     image: seanyee1227/pushandpull-server:latest
-    container_name: pushpull-server
+    container_name: pushandpull-server
     ports:
       - "21754:80"
     environment:


### PR DESCRIPTION
## 📚작업 내용

- 배포 방식을 docker run 단일 컨테이너에서 Docker Compose로 전환
- GitHub Actions 워크플로우에 SCP로 compose 파일 전송 스텝 추가
- SSH 배포 스크립트를 docker compose pull/up 방식으로 교체
- compose.prod.yaml에서 DB 컨테이너 분리 (외부 DB 사용)
- compose.prod.yaml에 Redis 컨테이너 및 내부 네트워크 추가
- appsettings.json / appsettings.Production.json의 민감 정보 플레이스홀더 제거 (공백으로 교체)
- 환경변수명 오타 수정: STEAM_API_KEY → STEAM_WEB_API_KEY

## ◀️참고 사항

DB는 compose에서 분리하여 외부 PostgreSQL 인스턴스를 사용합니다. Redis는 compose 내부 서비스로 운영하며, pushandpull-network 브릿지 네트워크로 연결됩니다. 시크릿(DB_CONNECTION_STRING, REDIS_CONNECTION_STRING, STEAM_WEB_API_KEY)은 GitHub Secrets에서 SSH 배포 시 .env 파일로 주입됩니다.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?


> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*