### PR TITLE
[ci] Codex advisory 검토 워크플로 추가

### DIFF
--- a/PushAndPull/.claude/skills/ship/SKILL.md
+++ b/PushAndPull/.claude/skills/ship/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ship
+argument-hint: <feature-description>
+description: Ship a feature through a gated Claude implementation pipeline with non-blocking Codex advisory review.
+allowed-tools: Bash, Read, Edit, Write, Agent
+---
+
+Ship the feature described in `$ARGUMENTS` through the following gated pipeline. Halt on any blocking failure.
+
+---
+
+## Phase 0 — Pre-check (blocking)
+
+1. Verify there are no uncommitted changes: `git status --porcelain`
+2. Report the current branch name.
+3. If uncommitted changes exist, stop and ask the user to commit or stash them first.
+
+---
+
+## Phase 1 — Planning (user approval gate)
+
+Spawn a sub-agent to produce a work contract for `$ARGUMENTS`:
+
+- List every file to be created or modified (path + one-line reason)
+- List every new endpoint or behavior change
+- List edge cases and error paths to handle
+- Estimate test scenarios needed
+
+Present the contract to the user.
+
+**Do NOT proceed to Phase 2 without explicit user approval.**
+
+---
+
+## Phase 2 — Implementation (blocking)
+
+Implement the approved contract:
+
+- Follow `.claude/rules/` conventions (architecture, code-style, domain-patterns, security, testing)
+- Create or modify services, repositories, controllers, DTOs, and exceptions as needed
+- Add or update unit tests in `PushAndPull.Test` mirroring production namespaces
+
+---
+
+## Phase 3 — Validation (blocking, auto-retry up to 2×)
+
+```bash
+dotnet build PushAndPull.sln
+dotnet test PushAndPull.Test/PushAndPull.Test.csproj
+```
+
+If either command fails, diagnose and fix, then retry. After 2 failed retries, stop and report the failure details.
+
+---
+
+## Phase 3.5 — Codex Advisory Review (non-blocking)
+
+```bash
+bash scripts/codex-review.sh --base origin/main --raw --timeout 120
+```
+
+If the script is missing or Codex is unavailable, log `[SKIPPED]` and continue.
+CRITICAL findings are recorded in the Phase 4 report but do **not** block the pipeline.
+
+---
+
+## Phase 4 — Report
+
+Summarize results in this format:
+
+```
+## Ship Report: <feature-description>
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Pre-check    | ✅ / ❌ | ... |
+| Planning     | ✅      | Approved by user |
+| Implementation | ✅ / ❌ | files changed |
+| Validation   | ✅ / ❌ | build + test results |
+| Codex Advisory | ✅ SKIPPED / findings | see below |
+
+### Codex Advisory Findings (advisory only — not blocking)
+<findings or "none">
+```

--- a/PushAndPull/AGENTS.md
+++ b/PushAndPull/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md — Codex Advisory Reviewer Context
+
+Push & Pull Server: Steam-authenticated game room management API (.NET 9, PostgreSQL, Redis).
+
+## Build & Test Commands
+
+```bash
+dotnet build PushAndPull.sln
+dotnet test PushAndPull.Test/PushAndPull.Test.csproj
+```
+
+## Absolute Prohibitions
+
+- Never commit secrets, API keys, or connection strings to the repo
+- Never use `git push --force` or `git commit --no-verify`
+- Never bypass `[SessionAuthorize]` on endpoints that modify state
+
+## Review Priority Order
+
+1. **Security** — Steam ticket validation paths, BCrypt usage, Redis session handling
+2. **Data integrity** — Room status transitions, atomic player count operations
+3. **Type safety** — Nullable reference types, EF Core tracking state bugs
+4. **Domain rules** — See below
+5. **Performance** — N+1 queries, missing indexes
+
+## Domain Integrity Rules
+
+- All read queries must use `AsNoTracking()` — tracked reads outside write paths are a bug
+- Player count increments must use `ExecuteUpdateAsync` (set-based) — `SaveChanges` on a tracked entity is a race condition
+- Password hashing must go through `IPasswordHasher` — calling `BCrypt.HashPassword` directly bypasses the workFactor contract
+- `[SessionAuthorize]` omission on a state-mutating endpoint requires an explicit comment explaining why
+- Room status comparisons must use the `RoomStatus` enum, never raw strings
+- Foreign key to `auth.user` must use `DeleteBehavior.Restrict` — cascade deletes on user data are forbidden
+
+## Forbidden Patterns
+
+- Hardcoded Steam API keys, DB connection strings, or Redis URIs in source files
+- Raw SQL strings without parameterization (Dapper queries must use anonymous objects)
+- `string` literals where `RoomStatus` enum values exist
+- Catching `Exception` without re-throwing or specific handling
+
+## Output Format
+
+For each finding:
+```
+[SEVERITY] File:Line — Description
+  → Suggested fix
+```
+Severity: `CRITICAL` | `WARNING` | `INFO`
+
+Group by severity, highest first.
+
+## What to Ignore
+
+- Code style preferences and naming conventions (those belong to CLAUDE.md)
+- General refactoring suggestions unrelated to domain rule violations
+- Test coverage opinions unless a critical path has zero coverage
+- Framework boilerplate that follows the established pattern in the codebase

--- a/PushAndPull/CLAUDE.md
+++ b/PushAndPull/CLAUDE.md
@@ -48,3 +48,27 @@ mcp__context7__query-docs(libraryId: "/stackexchange/stackexchange.redis", query
 ```
 
 `BCrypt.Net-Next`, `Moq`, and `Gamism.SDK.Extensions.AspNetCore` have no Context7 entry — refer to the source code directly.
+
+## Reference Docs
+
+- `.claude/rules/architecture.md` — directory structure and layering rules (Controllers → Services → Repositories)
+- `.claude/rules/code-style.md` — C# naming conventions, entity/DTO/async/Command-Result patterns
+- `.claude/rules/conventions.md` — DB naming, EF Core Fluent API config, CacheKey usage, DI registration
+- `.claude/rules/db-migration.md` — migration workflow, naming convention, entity modification patterns, rollback strategy
+- `.claude/rules/domain-patterns.md` — service, repository, and controller implementation patterns
+- `.claude/rules/global-patterns.md` — Steam auth, Redis session store, CacheKey, SessionAuthorize
+- `.claude/rules/testing.md` — test project structure, naming conventions, Moq patterns
+- `.claude/rules/flows.md` — Mermaid sequence diagrams for each API endpoint
+- `.claude/rules/verify.md` — build-and-verify workflow (auto build + test after every C# code change)
+- `.claude/rules/ask-user.md` — when to use AskUserQuestion (always applied)
+- `.claude/rules/test-fixer-trigger.md` — when to proactively offer the test-fixer agent (always applied)
+
+## Dual-Agent Workflow Setup
+
+This repo uses Claude Code (author) + Codex (advisory reviewer). One-time setup:
+
+```bash
+git config core.hooksPath ./hooks   # enable tracked pre-push hook
+```
+
+To skip Codex review on a push: `SKIP_CODEX=1 git push`

--- a/PushAndPull/CLAUDE.md
+++ b/PushAndPull/CLAUDE.md
@@ -68,7 +68,7 @@ mcp__context7__query-docs(libraryId: "/stackexchange/stackexchange.redis", query
 This repo uses Claude Code (author) + Codex (advisory reviewer). One-time setup:
 
 ```bash
-git config core.hooksPath ./hooks   # enable tracked pre-push hook
+git config core.hooksPath PushAndPull/hooks   # enable tracked pre-push hook
 ```
 
-To skip Codex review on a push: `SKIP_CODEX=1 git push`
+To skip Codex advisory review on a push: `SKIP_CODEX=1 git push`

--- a/PushAndPull/hooks/pre-push
+++ b/PushAndPull/hooks/pre-push
@@ -4,14 +4,10 @@
 # - Layer 2: warns on inline secret patterns (non-blocking)
 # - Layer 3: advisory Codex review (non-blocking, always exit 0)
 #
-# Skip entirely: SKIP_CODEX=1 git push
+# Skip advisory review: SKIP_CODEX=1 git push
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-
-if [[ "${SKIP_CODEX:-0}" == "1" ]]; then
-  echo "[pre-push] SKIP_CODEX=1 — advisory review skipped."
-  exit 0
-fi
+HOOK_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${HOOK_DIR}/.." && pwd)
 
 # ------------------------------------------------------------------
 # Resolve base branch
@@ -80,12 +76,17 @@ $WARNED && echo "[pre-push] Review the warnings above before pushing."
 # ------------------------------------------------------------------
 # Layer 3: Codex advisory review (non-blocking)
 # ------------------------------------------------------------------
+if [[ "${SKIP_CODEX:-0}" == "1" ]]; then
+  echo "[pre-push] SKIP_CODEX=1 — advisory review skipped."
+  exit 0
+fi
+
 echo ""
 echo "╔══════════════════════════════════════════════════════╗"
 echo "║  Advisory Codex Review  (push proceeds regardless)  ║"
 echo "╚══════════════════════════════════════════════════════╝"
 
-REVIEW_SCRIPT="${REPO_ROOT}/scripts/codex-review.sh"
+REVIEW_SCRIPT="${PROJECT_ROOT}/scripts/codex-review.sh"
 if [[ -x "$REVIEW_SCRIPT" ]]; then
   bash "$REVIEW_SCRIPT" --base "$BASE" --raw --timeout 90
 else

--- a/PushAndPull/hooks/pre-push
+++ b/PushAndPull/hooks/pre-push
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Advisory Codex review on every push.
+# - Layer 1: blocks pushes containing secret files (exit 1)
+# - Layer 2: warns on inline secret patterns (non-blocking)
+# - Layer 3: advisory Codex review (non-blocking, always exit 0)
+#
+# Skip entirely: SKIP_CODEX=1 git push
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+if [[ "${SKIP_CODEX:-0}" == "1" ]]; then
+  echo "[pre-push] SKIP_CODEX=1 — advisory review skipped."
+  exit 0
+fi
+
+# ------------------------------------------------------------------
+# Resolve base branch
+# ------------------------------------------------------------------
+BASE="${CODEX_BASE_BRANCH:-}"
+if [[ -z "$BASE" ]]; then
+  for candidate in origin/main origin/develop main develop; do
+    if git rev-parse --verify "$candidate" &>/dev/null; then
+      BASE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$BASE" ]]; then
+  echo "[pre-push] Could not determine base branch — advisory review skipped."
+  exit 0
+fi
+
+# ------------------------------------------------------------------
+# Detect committed changes vs base
+# ------------------------------------------------------------------
+CHANGED_FILES=$(git diff --name-only "$BASE"...HEAD 2>/dev/null)
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "[pre-push] No changes vs ${BASE} — advisory review skipped."
+  exit 0
+fi
+
+# ------------------------------------------------------------------
+# Layer 1: block secret files
+# ------------------------------------------------------------------
+BLOCKED=false
+while IFS= read -r file; do
+  # allowlist
+  case "$file" in
+    *.env.example|*.env.sample|*.env.template) continue ;;
+  esac
+  # blocklist patterns
+  case "$file" in
+    *.env|*.pem|*.key|*.p12|*.pfx)
+      echo "[pre-push] BLOCKED: secret file detected — ${file}"
+      BLOCKED=true
+      ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+if $BLOCKED; then
+  echo "[pre-push] Push aborted. Remove secret files and try again."
+  echo "           To skip advisory review only: SKIP_CODEX=1 git push"
+  exit 1
+fi
+
+# ------------------------------------------------------------------
+# Layer 2: warn on inline secret patterns (non-blocking)
+# ------------------------------------------------------------------
+DIFF=$(git diff "$BASE"...HEAD 2>/dev/null)
+WARNED=false
+for pattern in 'api_key\s*=' 'Bearer [A-Za-z0-9._-]\{20,\}' 'sk-[A-Za-z0-9]\{20,\}' 'ghp_[A-Za-z0-9]\{36,\}'; do
+  if echo "$DIFF" | grep -qE "^\+.*${pattern}"; then
+    echo "[pre-push] WARNING: possible secret pattern matched: ${pattern}"
+    WARNED=true
+  fi
+done
+$WARNED && echo "[pre-push] Review the warnings above before pushing."
+
+# ------------------------------------------------------------------
+# Layer 3: Codex advisory review (non-blocking)
+# ------------------------------------------------------------------
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  Advisory Codex Review  (push proceeds regardless)  ║"
+echo "╚══════════════════════════════════════════════════════╝"
+
+REVIEW_SCRIPT="${REPO_ROOT}/scripts/codex-review.sh"
+if [[ -x "$REVIEW_SCRIPT" ]]; then
+  bash "$REVIEW_SCRIPT" --base "$BASE" --raw --timeout 90
+else
+  echo "[pre-push] scripts/codex-review.sh not found — advisory review skipped."
+fi
+
+echo ""
+exit 0

--- a/PushAndPull/hooks/pre-push
+++ b/PushAndPull/hooks/pre-push
@@ -69,7 +69,7 @@ fi
 # ------------------------------------------------------------------
 DIFF=$(git diff "$BASE"...HEAD 2>/dev/null)
 WARNED=false
-for pattern in 'api_key\s*=' 'Bearer [A-Za-z0-9._-]\{20,\}' 'sk-[A-Za-z0-9]\{20,\}' 'ghp_[A-Za-z0-9]\{36,\}'; do
+for pattern in 'api_key\s*=' 'Bearer [A-Za-z0-9._-]{20,}' 'sk-[A-Za-z0-9]{20,}' 'ghp_[A-Za-z0-9]{36,}'; do
   if echo "$DIFF" | grep -qE "^\+.*${pattern}"; then
     echo "[pre-push] WARNING: possible secret pattern matched: ${pattern}"
     WARNED=true

--- a/PushAndPull/scripts/codex-review.sh
+++ b/PushAndPull/scripts/codex-review.sh
@@ -31,7 +31,7 @@ json_out() {  # status reason body
     jq -n --arg s "$status" --arg r "$reason" --arg b "$body" \
       '{status:$s,reason:$r,body:$b}'
   else
-    local esc_body; esc_body=$(printf '%s' "$body" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n')
+    local esc_body; esc_body=$(printf '%s' "$body" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/$/\\n/' | tr -d '\n')
     printf '{"status":"%s","reason":"%s","body":"%s"}\n' "$status" "$reason" "$esc_body"
   fi
 }

--- a/PushAndPull/scripts/codex-review.sh
+++ b/PushAndPull/scripts/codex-review.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Codex advisory review wrapper — always exits 0; never blocks the caller.
+# Usage:
+#   bash scripts/codex-review.sh --base origin/main [--timeout 120] [--raw]
+#   bash scripts/codex-review.sh "Review for security issues" [--timeout 120] [--raw]
+set -u
+
+TIMEOUT=120
+RAW=false
+BASE=""
+PROMPT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)     BASE="$2";    shift 2 ;;
+    --timeout)  TIMEOUT="$2"; shift 2 ;;
+    --raw)      RAW=true;     shift   ;;
+    *)          PROMPT="$1";  shift   ;;
+  esac
+done
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+# ------------------------------------------------------------------
+# Output helpers
+# ------------------------------------------------------------------
+json_out() {  # status reason body
+  local status="$1" reason="$2" body="$3"
+  if command -v jq &>/dev/null; then
+    jq -n --arg s "$status" --arg r "$reason" --arg b "$body" \
+      '{status:$s,reason:$r,body:$b}'
+  else
+    local esc_body; esc_body=$(printf '%s' "$body" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' | tr -d '\n')
+    printf '{"status":"%s","reason":"%s","body":"%s"}\n' "$status" "$reason" "$esc_body"
+  fi
+}
+
+emit() {  # status reason body
+  local status="$1" reason="$2" body="$3"
+  if $RAW; then
+    printf '[%s] %s\n' "$status" "$reason"
+    [[ -n "$body" ]] && printf '%s\n' "$body"
+  else
+    json_out "$status" "$reason" "$body"
+  fi
+}
+
+# ------------------------------------------------------------------
+# Preflight checks
+# ------------------------------------------------------------------
+if ! command -v codex &>/dev/null; then
+  emit "SKIPPED" "codex cli not found" ""
+  exit 0
+fi
+
+if ! codex login status &>/dev/null 2>&1 && [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  emit "SKIPPED" "codex not authenticated" ""
+  exit 0
+fi
+
+# ------------------------------------------------------------------
+# Run Codex with a bash-native timeout (no gtimeout dependency)
+# ------------------------------------------------------------------
+run_with_timeout() {
+  local cmd=("$@")
+  "${cmd[@]}" >"$TMPFILE" 2>&1 &
+  local pid=$!
+  local elapsed=0
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+    (( elapsed++ ))
+    if (( elapsed >= TIMEOUT )); then
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 124  # timeout exit code
+    fi
+  done
+  wait "$pid"
+  return $?
+}
+
+# ------------------------------------------------------------------
+# Choose mode: diff-based review vs free-form prompt
+# ------------------------------------------------------------------
+if [[ -n "$BASE" ]]; then
+  # Check whether `codex review --base` subcommand exists
+  if ! codex review --help 2>&1 | grep -q '\-\-base'; then
+    emit "SKIPPED" "codex review --base not supported in this CLI version" ""
+    exit 0
+  fi
+  run_with_timeout codex review --base "$BASE" \
+    -c model_reasoning_effort=high \
+    -c approval_policy=never
+else
+  run_with_timeout codex exec "$PROMPT" \
+    -c model_reasoning_effort=high \
+    -c approval_policy=never
+fi
+
+EXIT_CODE=$?
+BODY=$(cat "$TMPFILE")
+
+if [[ $EXIT_CODE -eq 124 ]]; then
+  emit "TIMEOUT" "exceeded ${TIMEOUT}s" ""
+  exit 0
+fi
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  emit "ERROR" "codex exited with code ${EXIT_CODE}" "$BODY"
+  exit 0
+fi
+
+emit "OK" "" "$BODY"
+exit 0


### PR DESCRIPTION
## Summary

- Codex advisory review용 `AGENTS.md`를 추가하였습니다.
- Claude ship 워크플로와 기존 Claude 문서에 Codex 검토 흐름을 반영하였습니다.
- pre-push hook과 `codex-review.sh` 래퍼를 추가하여 secret 파일 차단, inline secret 경고, 비차단 Codex 검토를 수행하도록 구성하였습니다.

## Changes

- `AGENTS.md`에 서버 도메인 규칙, 금지 패턴, 리뷰 출력 형식을 정리하였습니다.
- `.claude/skills/ship/SKILL.md`에 planning, implementation, validation, Codex advisory review 단계를 추가하였습니다.
- `CLAUDE.md`에 reference docs와 dual-agent workflow 설정 안내를 추가하였습니다.
- `hooks/pre-push`에서 secret 파일을 차단하고 advisory review를 실행하도록 추가하였습니다.
- `scripts/codex-review.sh`에서 Codex CLI 인증 및 지원 여부를 확인하고 timeout 가능한 review 실행을 제공하도록 추가하였습니다.

## Test

- 문서 및 hook/script 추가 변경으로 별도 빌드 테스트는 실행하지 않았습니다.
