### PR TITLE
[auth] 스팀 인증 회로 차단기 추가

### DIFF
--- a/PushAndPull/.gitignore
+++ b/PushAndPull/.gitignore
@@ -1,5 +1,6 @@
 ﻿# Claude Code
 PR_BODY.md
+specs/
 
 # Local environment secrets
 .env

--- a/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using PushAndPull.Domain.Auth.Config;
+using PushAndPull.Domain.Auth.Exception;
+using PushAndPull.Global.Auth;
+using PushAndPull.Global.Filter;
+
+namespace PushAndPull.Test.Service.Auth;
+
+public class SteamCircuitBreakerTests
+{
+    private static IConfiguration BuildConfig(int minimumThroughput = 2, int timeoutSeconds = 5)
+        => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Steam:WebApiKey"] = "test-key-name",
+            ["test-key-name"] = "test-api-key",
+            ["Steam:AppId"] = "480",
+            ["Steam:CircuitBreaker:FailureRatio"] = "0.5",
+            ["Steam:CircuitBreaker:SamplingDurationSeconds"] = "2",
+            ["Steam:CircuitBreaker:MinimumThroughput"] = minimumThroughput.ToString(),
+            ["Steam:CircuitBreaker:BreakDurationSeconds"] = "1",
+            ["Steam:CircuitBreaker:RequestTimeoutSeconds"] = timeoutSeconds.ToString(),
+        }).Build();
+
+    private static (IAuthTicketValidator Validator, CountingHandler Handler) BuildValidator(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond,
+        IConfiguration? config = null)
+    {
+        var resolvedConfig = config ?? BuildConfig();
+        var handler = new CountingHandler(respond);
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(resolvedConfig);
+        services.AddLogging();
+        services.AddAuthServices(resolvedConfig);
+        services.AddHttpClient<IAuthTicketValidator, SteamAuthTicketValidator>()
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+        var provider = services.BuildServiceProvider();
+        return (provider.GetRequiredService<IAuthTicketValidator>(), handler);
+    }
+
+    private static HttpResponseMessage ServerError()
+        => new(HttpStatusCode.InternalServerError);
+
+    public class WhenFailuresBelowThreshold
+    {
+        [Fact]
+        public async Task It_DoesNotOpenCircuit()
+        {
+            var (validator, handler) = BuildValidator(
+                (_, _) => Task.FromResult(ServerError()),
+                BuildConfig(minimumThroughput: 3));
+
+            // MinimumThroughput - 1 = 2 failures; CB should NOT open
+            for (var i = 0; i < 2; i++)
+                await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+
+            // Third call goes to actual handler (circuit closed), not BrokenCircuitException
+            await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+            Assert.Equal(3, handler.CallCount);
+        }
+    }
+
+    public class WhenFailureRatioExceeded
+    {
+        [Fact]
+        public async Task It_OpensCircuitAndNextCallThrowsSteamCircuitOpenException()
+        {
+            var (validator, handler) = BuildValidator(
+                (_, _) => Task.FromResult(ServerError()));
+
+            // Reach MinimumThroughput (2) with 100% failure rate
+            for (var i = 0; i < 2; i++)
+                await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+
+            // Circuit is now open — next call must NOT reach handler
+            await Assert.ThrowsAsync<SteamCircuitOpenException>(
+                () => validator.ValidateAsync("ticket"));
+
+            Assert.Equal(2, handler.CallCount);
+        }
+    }
+
+    public class WhenCircuitOpenAndBreakDurationElapsed
+    {
+        [Fact]
+        public async Task It_AllowsProbeRequest()
+        {
+            var (validator, handler) = BuildValidator(
+                (_, _) => Task.FromResult(ServerError()));
+
+            for (var i = 0; i < 2; i++)
+                await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+
+            // Confirm circuit is open
+            await Assert.ThrowsAsync<SteamCircuitOpenException>(
+                () => validator.ValidateAsync("ticket"));
+
+            // Wait for BreakDuration (1s) to pass → Half-Open
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+
+            // Probe request should reach the handler (still fails, but circuit was half-open)
+            await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+            Assert.Equal(3, handler.CallCount);
+        }
+    }
+
+    public class WhenSteamApiHangs
+    {
+        [Fact]
+        public async Task It_TimesOutAndContributesToCircuitBreaker()
+        {
+            var (validator, handler) = BuildValidator(
+                async (_, ct) =>
+                {
+                    await Task.Delay(Timeout.Infinite, ct);
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                },
+                BuildConfig(minimumThroughput: 2, timeoutSeconds: 1));
+
+            // Two timeout failures should open the circuit
+            for (var i = 0; i < 2; i++)
+                await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
+
+            await Assert.ThrowsAsync<SteamCircuitOpenException>(
+                () => validator.ValidateAsync("ticket"));
+
+            Assert.Equal(2, handler.CallCount);
+        }
+    }
+
+    public class WhenCircuitOpenExceptionIsThrown
+    {
+        private readonly CircuitBreakerExceptionFilter _sut = new();
+
+        private static ExceptionContext CreateContext(Exception ex)
+        {
+            var actionContext = new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ActionDescriptor());
+            return new ExceptionContext(actionContext, []) { Exception = ex };
+        }
+
+        [Fact]
+        public void It_Returns503CommonApiResponse()
+        {
+            var context = CreateContext(
+                new SteamCircuitOpenException(new Exception("circuit open")));
+
+            _sut.OnException(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
+            Assert.True(context.ExceptionHandled);
+        }
+
+        [Fact]
+        public void It_DoesNotHandleOtherExceptions()
+        {
+            var context = CreateContext(new InvalidOperationException("other"));
+
+            _sut.OnException(context);
+
+            Assert.Null(context.Result);
+            Assert.False(context.ExceptionHandled);
+        }
+    }
+
+    private sealed class CountingHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond)
+        : HttpMessageHandler
+    {
+        private int _callCount;
+        public int CallCount => _callCount;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _callCount);
+            return await respond(request, cancellationToken);
+        }
+    }
+}

--- a/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
@@ -31,13 +31,16 @@ public class SteamCircuitBreakerTests
 
     private static (IAuthTicketValidator Validator, CountingHandler Handler) BuildValidator(
         Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond,
-        IConfiguration? config = null)
+        IConfiguration? config = null,
+        TimeProvider? timeProvider = null)
     {
         var resolvedConfig = config ?? BuildConfig();
         var handler = new CountingHandler(respond);
         var services = new ServiceCollection();
         services.AddSingleton<IConfiguration>(resolvedConfig);
         services.AddLogging();
+        if (timeProvider != null)
+            services.AddSingleton<TimeProvider>(timeProvider);
         services.AddAuthServices(resolvedConfig);
         services.AddHttpClient<IAuthTicketValidator, SteamAuthTicketValidator>()
             .ConfigurePrimaryHttpMessageHandler(() => handler);
@@ -92,8 +95,10 @@ public class SteamCircuitBreakerTests
         [Fact]
         public async Task It_AllowsProbeRequest()
         {
+            var fakeTime = new FakeTimeProvider();
             var (validator, handler) = BuildValidator(
-                (_, _) => Task.FromResult(ServerError()));
+                (_, _) => Task.FromResult(ServerError()),
+                timeProvider: fakeTime);
 
             for (var i = 0; i < 2; i++)
                 await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
@@ -102,8 +107,8 @@ public class SteamCircuitBreakerTests
             await Assert.ThrowsAsync<SteamCircuitOpenException>(
                 () => validator.ValidateAsync("ticket"));
 
-            // Wait for BreakDuration (1s) to pass → Half-Open
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            // Advance past BreakDuration (1s) without real wall-clock wait
+            fakeTime.Advance(TimeSpan.FromSeconds(2));
 
             // Probe request should reach the handler (still fails, but circuit was half-open)
             await Assert.ThrowsAsync<SteamApiException>(() => validator.ValidateAsync("ticket"));
@@ -170,6 +175,22 @@ public class SteamCircuitBreakerTests
 
             Assert.Null(context.Result);
             Assert.False(context.ExceptionHandled);
+        }
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = DateTimeOffset.UtcNow;
+        private long _timestamp = global::System.Diagnostics.Stopwatch.GetTimestamp();
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+        public override long GetTimestamp() => _timestamp;
+        public override long TimestampFrequency => global::System.Diagnostics.Stopwatch.Frequency;
+
+        public void Advance(TimeSpan duration)
+        {
+            _utcNow = _utcNow.Add(duration);
+            _timestamp += (long)(duration.TotalSeconds * global::System.Diagnostics.Stopwatch.Frequency);
         }
     }
 

--- a/PushAndPull/PushAndPull/Domain/Auth/Config/AuthServiceConfig.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Config/AuthServiceConfig.cs
@@ -35,6 +35,8 @@ public static class AuthServiceConfig
             .AddHttpClient<IAuthTicketValidator, SteamAuthTicketValidator>()
             .AddResilienceHandler("steam-cb", (builder, context) =>
             {
+                builder.TimeProvider = context.ServiceProvider.GetService<TimeProvider>() ?? TimeProvider.System;
+
                 var logger = context.ServiceProvider
                     .GetRequiredService<ILogger<SteamAuthTicketValidator>>();
 

--- a/PushAndPull/PushAndPull/Domain/Auth/Config/AuthServiceConfig.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Config/AuthServiceConfig.cs
@@ -1,3 +1,7 @@
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Timeout;
 using PushAndPull.Domain.Auth.Repository;
 using PushAndPull.Domain.Auth.Repository.Interface;
 using PushAndPull.Domain.Auth.Service;
@@ -8,9 +12,63 @@ namespace PushAndPull.Domain.Auth.Config;
 
 public static class AuthServiceConfig
 {
-    public static IServiceCollection AddAuthServices(this IServiceCollection services)
+    public static IServiceCollection AddAuthServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
-        services.AddHttpClient<IAuthTicketValidator, SteamAuthTicketValidator>();
+        var cbOptions = configuration
+            .GetSection("Steam:CircuitBreaker")
+            .Get<CircuitBreakerOptions>() ?? new CircuitBreakerOptions();
+
+        if (cbOptions.FailureRatio is <= 0 or > 1)
+            throw new ArgumentException("FailureRatio must be between 0 (exclusive) and 1 (inclusive).");
+        if (cbOptions.SamplingDurationSeconds <= 0)
+            throw new ArgumentException("SamplingDurationSeconds must be greater than 0.");
+        if (cbOptions.BreakDurationSeconds <= 0)
+            throw new ArgumentException("BreakDurationSeconds must be greater than 0.");
+        if (cbOptions.RequestTimeoutSeconds <= 0)
+            throw new ArgumentException("RequestTimeoutSeconds must be greater than 0.");
+        if (cbOptions.MinimumThroughput < 2)
+            throw new ArgumentException("MinimumThroughput must be at least 2 (Polly v8 requirement).");
+
+        services
+            .AddHttpClient<IAuthTicketValidator, SteamAuthTicketValidator>()
+            .AddResilienceHandler("steam-cb", (builder, context) =>
+            {
+                var logger = context.ServiceProvider
+                    .GetRequiredService<ILogger<SteamAuthTicketValidator>>();
+
+                builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+                {
+                    FailureRatio = cbOptions.FailureRatio,
+                    SamplingDuration = TimeSpan.FromSeconds(cbOptions.SamplingDurationSeconds),
+                    MinimumThroughput = cbOptions.MinimumThroughput,
+                    BreakDuration = TimeSpan.FromSeconds(cbOptions.BreakDurationSeconds),
+                    OnOpened = args =>
+                    {
+                        logger.LogWarning(
+                            "Steam API circuit breaker opened. Break for {Duration}s.",
+                            cbOptions.BreakDurationSeconds);
+                        return ValueTask.CompletedTask;
+                    },
+                    OnClosed = _ =>
+                    {
+                        logger.LogInformation("Steam API circuit breaker closed.");
+                        return ValueTask.CompletedTask;
+                    },
+                    OnHalfOpened = _ =>
+                    {
+                        logger.LogInformation("Steam API circuit breaker half-opened.");
+                        return ValueTask.CompletedTask;
+                    }
+                });
+
+                builder.AddTimeout(new HttpTimeoutStrategyOptions
+                {
+                    Timeout = TimeSpan.FromSeconds(cbOptions.RequestTimeoutSeconds)
+                });
+            });
+
         services.AddScoped<ISessionService, SessionService>();
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<ILoginService, LoginService>();

--- a/PushAndPull/PushAndPull/Domain/Auth/Config/CircuitBreakerOptions.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Config/CircuitBreakerOptions.cs
@@ -1,0 +1,10 @@
+namespace PushAndPull.Domain.Auth.Config;
+
+public class CircuitBreakerOptions
+{
+    public double FailureRatio { get; init; } = 0.5;
+    public int SamplingDurationSeconds { get; init; } = 30;
+    public int MinimumThroughput { get; init; } = 5;
+    public int BreakDurationSeconds { get; init; } = 60;
+    public int RequestTimeoutSeconds { get; init; } = 10;
+}

--- a/PushAndPull/PushAndPull/Domain/Auth/Exception/SteamCircuitOpenException.cs
+++ b/PushAndPull/PushAndPull/Domain/Auth/Exception/SteamCircuitOpenException.cs
@@ -1,0 +1,4 @@
+namespace PushAndPull.Domain.Auth.Exception;
+
+public class SteamCircuitOpenException(System.Exception innerException)
+    : SteamApiException("STEAM_API_CIRCUIT_OPEN", innerException);

--- a/PushAndPull/PushAndPull/Global/Auth/SteamAuthTicketValidator.cs
+++ b/PushAndPull/PushAndPull/Global/Auth/SteamAuthTicketValidator.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using Polly.CircuitBreaker;
+using Polly.Timeout;
 using PushAndPull.Domain.Auth.Exception;
 using PushAndPull.Global.Auth.Dto;
 
@@ -40,6 +42,14 @@ public class SteamAuthTicketValidator : IAuthTicketValidator
             var response = await CallSteamApiAsync(ticket);
             var steamResponse = await ParseResponseAsync(response);
             return ValidateAndCreateResult(steamResponse);
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new SteamCircuitOpenException(ex);
+        }
+        catch (TimeoutRejectedException ex)
+        {
+            throw new SteamApiException("STEAM_API_TIMEOUT", ex);
         }
         catch (HttpRequestException ex)
         {

--- a/PushAndPull/PushAndPull/Global/Filter/CircuitBreakerExceptionFilter.cs
+++ b/PushAndPull/PushAndPull/Global/Filter/CircuitBreakerExceptionFilter.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using Gamism.SDK.Core.Network;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PushAndPull.Domain.Auth.Exception;
+
+namespace PushAndPull.Global.Filter;
+
+public class CircuitBreakerExceptionFilter : IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is not SteamCircuitOpenException)
+            return;
+
+        context.Result = new ObjectResult(
+            CommonApiResponse.Error(
+                "스팀 인증 서버에 일시적으로 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+                HttpStatusCode.ServiceUnavailable))
+        {
+            StatusCode = StatusCodes.Status503ServiceUnavailable
+        };
+        context.ExceptionHandled = true;
+    }
+}

--- a/PushAndPull/PushAndPull/Program.cs
+++ b/PushAndPull/PushAndPull/Program.cs
@@ -3,11 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using PushAndPull.Domain.Auth.Config;
 using PushAndPull.Domain.Room.Config;
 using PushAndPull.Global.Config;
+using PushAndPull.Global.Filter;
 using PushAndPull.Global.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+    options.Filters.Add<CircuitBreakerExceptionFilter>());
 builder.Services.AddGamismSdk(options =>
 {
     options.Swagger.Title = "Push & Pull API";
@@ -18,7 +20,7 @@ builder.Services.AddGamismSdk(options =>
 builder.Services.AddDatabase(builder.Configuration);
 builder.Services.AddRedis(builder.Configuration);
 builder.Services.AddGlobalServices();
-builder.Services.AddAuthServices();
+builder.Services.AddAuthServices(builder.Configuration);
 builder.Services.AddRoomServices();
 builder.Services.AddRateLimit();
 

--- a/PushAndPull/PushAndPull/PushAndPull.csproj
+++ b/PushAndPull/PushAndPull/PushAndPull.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Npgsql" Version="9.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/PushAndPull/PushAndPull/appsettings.Development.json
+++ b/PushAndPull/PushAndPull/appsettings.Development.json
@@ -7,7 +7,14 @@
   },
   "Steam": {
     "WebApiKey": "",
-    "AppId": 480
+    "AppId": 480,
+    "CircuitBreaker": {
+      "FailureRatio": 0.5,
+      "SamplingDurationSeconds": 30,
+      "MinimumThroughput": 5,
+      "BreakDurationSeconds": 60,
+      "RequestTimeoutSeconds": 10
+    }
   },
   "Redis": {
     "ConnectionString": ""

--- a/PushAndPull/PushAndPull/appsettings.Production.json
+++ b/PushAndPull/PushAndPull/appsettings.Production.json
@@ -7,7 +7,14 @@
   },
   "Steam": {
     "WebApiKey": "Steam-ApiKey",
-    "AppId": 0
+    "AppId": 0,
+    "CircuitBreaker": {
+      "FailureRatio": 0.5,
+      "SamplingDurationSeconds": 30,
+      "MinimumThroughput": 5,
+      "BreakDurationSeconds": 60,
+      "RequestTimeoutSeconds": 10
+    }
   },
   "Redis": {
     "ConnectionString": ""

--- a/PushAndPull/PushAndPull/appsettings.json
+++ b/PushAndPull/PushAndPull/appsettings.json
@@ -8,7 +8,14 @@
   "AllowedHosts": "*",
   "Steam": {
     "WebApiKey": "",
-    "AppId": 0
+    "AppId": 0,
+    "CircuitBreaker": {
+      "FailureRatio": 0.5,
+      "SamplingDurationSeconds": 30,
+      "MinimumThroughput": 5,
+      "BreakDurationSeconds": 60,
+      "RequestTimeoutSeconds": 10
+    }
   },
   "ConnectionStrings": {
     "Default": ""


### PR DESCRIPTION
## 변경 사항

- 스팀 인증 HTTP 클라이언트에 Polly 기반 회로 차단기와 요청 타임아웃을 추가하였습니다.
- 회로 차단 상태를 `SteamCircuitOpenException`으로 변환하고, 전역 예외 필터에서 503 응답으로 처리하도록 추가하였습니다.
- 환경별 `Steam:CircuitBreaker` 설정과 옵션 검증 로직을 추가하였습니다.
- 회로 차단기 동작, 타임아웃, 503 응답 변환을 검증하는 인증 테스트를 추가하였습니다.

## 테스트

- `dotnet test PushAndPull.sln --no-restore`를 시도하였으나 현재 환경에 `dotnet` CLI가 없어 실행하지 못하였습니다.

## 참고 사항

- `.github/PULL_REQUEST_TEMPLATE.md` 파일이 저장소에서 확인되지 않아 위 구조로 본문을 작성하였습니다.
