### PR TITLE
[config] Claude worktree 제외 규칙 추가

### DIFF
--- a/PushAndPull/.gitignore
+++ b/PushAndPull/.gitignore
@@ -1,6 +1,7 @@
 ﻿# Claude Code
 PR_BODY.md
 specs/
+.claude/worktrees/
 
 # Local environment secrets
 .env


### PR DESCRIPTION
## 개요

Claude 작업 중 생성되는 worktree 디렉터리가 추적되지 않도록 `.gitignore`에 제외 규칙을 추가하였습니다.

## 변경 사항

- `.claude/worktrees/` 디렉터리를 Git 추적 대상에서 제외하였습니다.

## 테스트

- 별도 런타임 동작 변경이 없어 테스트는 수행하지 않았습니다.
