### PR TITLE
[room] 끊긴 플레이어 재접속 기능 추가

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -16,5 +16,5 @@ paths:
 - Use PostgreSQL `timestamptz` for `DateTimeOffset` values.
 - Do not expose `IQueryable` from repositories.
 - Do not edit committed migrations to rewrite history; add a new migration for schema changes.
-- After entity or configuration changes, create a migration with a descriptive PascalCase name.
+- After entity or configuration changes, create a migration with a descriptive PascalCase name using the `db-migrate` skill (do not run `dotnet ef migrations add` ad hoc).
 - Review generated migrations before committing to ensure no unrelated schema churn is included.

--- a/.claude/skills/db-migrate/SKILL.md
+++ b/.claude/skills/db-migrate/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: db-migrate
+description: Generate and review an EF Core migration for the PushAndPull project. Builds first, runs `dotnet ef migrations add` with the correct project paths, reviews the generated Up/Down for unintended schema churn, and covers remove/redo. Does NOT apply migrations to a database.
+---
+
+Use this skill whenever an entity or `IEntityTypeConfiguration` change requires a schema migration. Scope is **generate + review only** — applying to a database (`dotnet ef database update`) is handled by CI / manual deployment and is out of scope here.
+
+All commands run from the repository root. The API project doubles as the migrations and startup project:
+
+- Project / startup project: `PushAndPull/PushAndPull/PushAndPull.csproj`
+- Migrations live in that project's `Migrations/` folder (the default output dir — do not override it).
+- `migrations add` does **not** connect to a database, so no `DB_CONNECTION_STRING` is needed to generate.
+
+## Step 1 — Build first
+
+A migration is generated from the compiled model, so the solution must build.
+
+```bash
+dotnet build PushAndPull/PushAndPull.sln --nologo
+```
+
+Fix any build errors before continuing.
+
+## Step 2 — Add the migration
+
+Choose a descriptive PascalCase name that reflects the schema change (e.g. `AddGuestLastHeartbeatAt`, `CreateRoomTable`).
+
+```bash
+dotnet ef migrations add <PascalCaseName> \
+  --project PushAndPull/PushAndPull/PushAndPull.csproj \
+  --startup-project PushAndPull/PushAndPull/PushAndPull.csproj
+```
+
+This creates `Migrations/<timestamp>_<PascalCaseName>.cs`, its `.Designer.cs`, and updates `AppDbContextModelSnapshot.cs`.
+
+## Step 3 — Review the generated migration (required)
+
+Open `Migrations/<timestamp>_<PascalCaseName>.cs` and confirm `Up`/`Down` contain **only** the schema change you intended.
+
+- Each operation must trace to your entity/config change. Watch for snake_case column/table names and `timestamptz` for `DateTimeOffset` (project conventions).
+- If unrelated operations appear (columns, tables, indexes, or type changes you did not make), the model snapshot had drifted. Stop and investigate before committing — do not ship unexplained churn.
+
+## Step 4 — Verify
+
+Per the project verification rules, after adding the migration:
+
+```bash
+dotnet build PushAndPull/PushAndPull.sln --nologo
+dotnet test PushAndPull/PushAndPull.sln --nologo
+```
+
+## If the migration is wrong — remove and redo
+
+Only safe when the migration has **not** been committed/shared or applied to any database (committed migration history must not be rewritten).
+
+```bash
+dotnet ef migrations remove \
+  --project PushAndPull/PushAndPull/PushAndPull.csproj \
+  --startup-project PushAndPull/PushAndPull/PushAndPull.csproj
+```
+
+Then adjust the entity/config and repeat from Step 1. For a schema change on top of an **already-committed** migration, add a new migration instead of editing the old one.

--- a/.claude/skills/write-pr/references/labels.md
+++ b/.claude/skills/write-pr/references/labels.md
@@ -6,7 +6,7 @@ Select **1–2 labels** from the PR-eligible list below. Do NOT use issue-only o
 
 | Label               | When to use                                               |
 |---------------------|-----------------------------------------------------------|
-| `enhancement:개선작업`  | New feature, improvement to existing feature, refactoring |
+| `enhancement:개선사항`  | New feature, improvement to existing feature, refactoring |
 | `bug:버그`            | Bug fix                                                   |
 | `documentation:문서화` | Docs-only changes (README, CONTRIBUTING, comments)        |
 | `release:릴리즈`       | Release preparation or version bump                       |
@@ -26,8 +26,8 @@ Select **1–2 labels** from the PR-eligible list below. Do NOT use issue-only o
 
 ```
 Bug fix?          → bug:버그
-New feature or improvement? → enhancement:개선작업
+New feature or improvement? → enhancement:개선사항
 Docs only?        → documentation:문서화
 Release?          → release:릴리즈
-Unsure?           → enhancement:개선작업
+Unsure?           → enhancement:개선사항
 ```

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,6 +6,7 @@
 /contentModel.xml
 /modules.xml
 /.idea.Push-Pull-server.iml
+/indexLayout.xml
 # 쿼리 파일을 포함한 무시된 디폴트 폴더
 /queries/
 # Datasource local storage ignored files

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/PushAndPull/PushAndPull.Test/Service/Room/HeartbeatRoomServiceTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Room/HeartbeatRoomServiceTests.cs
@@ -10,6 +10,7 @@ namespace Tests.Service.Room;
 public class HeartbeatRoomServiceTests
 {
     private const ulong HostSteamId = 76561198000000001UL;
+    private const ulong GuestSteamId = 76561198000000003UL;
     private const ulong OtherSteamId = 76561198000000002UL;
 
     private sealed class FixedTimeProvider : TimeProvider
@@ -77,14 +78,42 @@ public class HeartbeatRoomServiceTests
         }
     }
 
-    public class WhenANonHostSendsAHeartbeat
+    public class WhenTheGuestSendsAHeartbeat
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly HeartbeatRoomService _sut;
+
+        private const string RoomCode = "BEAT04";
+        private static readonly DateTimeOffset Now = new(2026, 6, 11, 12, 0, 0, TimeSpan.Zero);
+
+        public WhenTheGuestSendsAHeartbeat()
+        {
+            _roomRepositoryMock
+                .Setup(r => r.UpdateHeartbeatAsync(RoomCode, GuestSteamId, Now, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            _sut = new HeartbeatRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_UpdatesTheHeartbeatWithTheCurrentTime()
+        {
+            await _sut.ExecuteAsync(new HeartbeatRoomCommand(RoomCode, GuestSteamId));
+
+            _roomRepositoryMock.Verify(
+                r => r.UpdateHeartbeatAsync(RoomCode, GuestSteamId, Now, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+
+    public class WhenANonParticipantSendsAHeartbeat
     {
         private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
         private readonly HeartbeatRoomService _sut;
 
         private const string RoomCode = "BEAT02";
 
-        public WhenANonHostSendsAHeartbeat()
+        public WhenANonParticipantSendsAHeartbeat()
         {
             var room = new EntityRoom(RoomCode, "Host Room", 111UL, HostSteamId, false, null);
 
@@ -100,9 +129,9 @@ public class HeartbeatRoomServiceTests
         }
 
         [Fact]
-        public async Task It_ThrowsNotRoomHostException()
+        public async Task It_ThrowsRoomNotParticipantException()
         {
-            await Assert.ThrowsAsync<NotRoomHostException>(
+            await Assert.ThrowsAsync<RoomNotParticipantException>(
                 () => _sut.ExecuteAsync(new HeartbeatRoomCommand(RoomCode, OtherSteamId)));
         }
     }

--- a/PushAndPull/PushAndPull.Test/Service/Room/ReconnectRoomServiceTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Room/ReconnectRoomServiceTests.cs
@@ -1,0 +1,232 @@
+using Moq;
+using PushAndPull.Domain.Room.Exception;
+using PushAndPull.Domain.Room.Repository.Interface;
+using PushAndPull.Domain.Room.Service;
+using PushAndPull.Domain.Room.Service.Interface;
+using EntityRoom = PushAndPull.Domain.Room.Entity.Room;
+
+namespace Tests.Service.Room;
+
+public class ReconnectRoomServiceTests
+{
+    private const ulong HostSteamId = 76561198000000001UL;
+    private const ulong GuestSteamId = 76561198000000003UL;
+    private const ulong OtherSteamId = 76561198000000002UL;
+
+    private static readonly DateTimeOffset Now = new(2026, 6, 11, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public FixedTimeProvider(DateTimeOffset utcNow) => _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+    }
+
+    // GuestSteamId는 리포지토리의 ExecuteUpdate로만 채워지므로, 단위 테스트에서는 private setter를 reflection으로 설정한다.
+    private static EntityRoom CreateRoomWithGuest(string roomCode, ulong steamLobbyId, ulong hostSteamId, ulong guestSteamId)
+    {
+        var room = new EntityRoom(roomCode, "Room", steamLobbyId, hostSteamId, false, null);
+        typeof(EntityRoom)
+            .GetProperty(nameof(EntityRoom.GuestSteamId))!
+            .SetValue(room, guestSteamId);
+        return room;
+    }
+
+    public class WhenTheHostReconnects
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "RECN01";
+        private const ulong SteamLobbyId = 444UL;
+
+        public WhenTheHostReconnects()
+        {
+            var room = new EntityRoom(RoomCode, "Active Room", SteamLobbyId, HostSteamId, false, null);
+
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(room);
+
+            _roomRepositoryMock
+                .Setup(r => r.UpdateHeartbeatAsync(RoomCode, HostSteamId, Now, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ReturnsTheSteamLobbyIdWithHostRole()
+        {
+            var result = await _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, HostSteamId));
+
+            Assert.Equal(SteamLobbyId, result.SteamLobbyId);
+            Assert.Equal("Host", result.Role);
+        }
+
+        [Fact]
+        public async Task It_ResetsTheHeartbeat()
+        {
+            await _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, HostSteamId));
+
+            _roomRepositoryMock.Verify(
+                r => r.UpdateHeartbeatAsync(RoomCode, HostSteamId, Now, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+
+    public class WhenTheGuestReconnects
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "RECN02";
+        private const ulong SteamLobbyId = 555UL;
+
+        public WhenTheGuestReconnects()
+        {
+            var room = CreateRoomWithGuest(RoomCode, SteamLobbyId, HostSteamId, GuestSteamId);
+
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(room);
+
+            _roomRepositoryMock
+                .Setup(r => r.UpdateHeartbeatAsync(RoomCode, GuestSteamId, Now, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ReturnsTheSteamLobbyIdWithGuestRole()
+        {
+            var result = await _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, GuestSteamId));
+
+            Assert.Equal(SteamLobbyId, result.SteamLobbyId);
+            Assert.Equal("Guest", result.Role);
+        }
+    }
+
+    public class WhenTheRoomDoesNotExist
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "NOTEXIST";
+
+        public WhenTheRoomDoesNotExist()
+        {
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((EntityRoom?)null);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ThrowsRoomNotFoundException()
+        {
+            await Assert.ThrowsAsync<RoomNotFoundException>(
+                () => _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, HostSteamId)));
+        }
+    }
+
+    public class WhenTheRoomIsNotActive
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "CLOSED1";
+
+        public WhenTheRoomIsNotActive()
+        {
+            var closedRoom = new EntityRoom(RoomCode, "Closed Room", 111UL, HostSteamId, false, null);
+            closedRoom.Close();
+
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(closedRoom);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ThrowsRoomNotActiveException()
+        {
+            await Assert.ThrowsAsync<RoomNotActiveException>(
+                () => _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, HostSteamId)));
+        }
+    }
+
+    public class WhenANonParticipantReconnects
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "RECN03";
+
+        public WhenANonParticipantReconnects()
+        {
+            var room = new EntityRoom(RoomCode, "Active Room", 666UL, HostSteamId, false, null);
+
+            _roomRepositoryMock
+                .Setup(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(room);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ThrowsRoomNotParticipantException()
+        {
+            await Assert.ThrowsAsync<RoomNotParticipantException>(
+                () => _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, OtherSteamId)));
+        }
+
+        [Fact]
+        public async Task It_DoesNotUpdateTheHeartbeat()
+        {
+            await Assert.ThrowsAsync<RoomNotParticipantException>(
+                () => _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, OtherSteamId)));
+
+            _roomRepositoryMock.Verify(
+                r => r.UpdateHeartbeatAsync(It.IsAny<string>(), It.IsAny<ulong>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+
+    public class WhenTheGuestSlotIsLostInARace
+    {
+        private readonly Mock<IRoomRepository> _roomRepositoryMock = new();
+        private readonly ReconnectRoomService _sut;
+
+        private const string RoomCode = "RACE01";
+
+        public WhenTheGuestSlotIsLostInARace()
+        {
+            var roomWithGuest = CreateRoomWithGuest(RoomCode, 777UL, HostSteamId, GuestSteamId);
+            var roomWithoutGuest = new EntityRoom(RoomCode, "Room", 777UL, HostSteamId, false, null);
+
+            _roomRepositoryMock
+                .SetupSequence(r => r.GetAsync(RoomCode, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(roomWithGuest)
+                .ReturnsAsync(roomWithoutGuest);
+
+            _roomRepositoryMock
+                .Setup(r => r.UpdateHeartbeatAsync(RoomCode, GuestSteamId, Now, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            _sut = new ReconnectRoomService(_roomRepositoryMock.Object, new FixedTimeProvider(Now));
+        }
+
+        [Fact]
+        public async Task It_ThrowsRoomNotParticipantException()
+        {
+            await Assert.ThrowsAsync<RoomNotParticipantException>(
+                () => _sut.ExecuteAsync(new ReconnectRoomCommand(RoomCode, GuestSteamId)));
+        }
+    }
+}

--- a/PushAndPull/PushAndPull.Test/Service/Room/StaleRoomCleanupServiceTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Room/StaleRoomCleanupServiceTests.cs
@@ -55,5 +55,16 @@ public class StaleRoomCleanupServiceTests
                 r => r.CloseStaleRoomsAsync(expectedCutoff, It.IsAny<CancellationToken>()),
                 Times.Once);
         }
+
+        [Fact]
+        public async Task It_FreesGuestSlotsStaleSinceTheHeartbeatTimeout()
+        {
+            await _sut.SweepOnceAsync(CancellationToken.None);
+
+            var expectedCutoff = Now.AddSeconds(-HeartbeatTimeoutSeconds);
+            _roomRepositoryMock.Verify(
+                r => r.FreeStaleGuestsAsync(expectedCutoff, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
     }
 }

--- a/PushAndPull/PushAndPull/Domain/Room/Config/RoomServiceConfig.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Config/RoomServiceConfig.cs
@@ -24,6 +24,7 @@ public static class RoomServiceConfig
         services.AddScoped<ILeaveRoomService, LeaveRoomService>();
         services.AddScoped<ICloseRoomService, CloseRoomService>();
         services.AddScoped<IHeartbeatRoomService, HeartbeatRoomService>();
+        services.AddScoped<IReconnectRoomService, ReconnectRoomService>();
         services.AddHostedService<StaleRoomCleanupService>();
         return services;
     }

--- a/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
@@ -143,6 +143,7 @@ public class RoomController : ControllerBase
 
     [SessionAuthorize]
     [HttpPost("{roomCode}/reconnect")]
+    [EnableRateLimiting("join_room")]
     public async Task<CommonApiResponse<ReconnectRoomResponse>> Reconnect(
         [FromRoute] string roomCode,
         CancellationToken ct

--- a/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Controller/RoomController.cs
@@ -19,6 +19,7 @@ public class RoomController : ControllerBase
     private readonly ILeaveRoomService _leaveRoomService;
     private readonly ICloseRoomService _closeRoomService;
     private readonly IHeartbeatRoomService _heartbeatRoomService;
+    private readonly IReconnectRoomService _reconnectRoomService;
 
     public RoomController(
         ICreateRoomService createRoomService,
@@ -27,7 +28,8 @@ public class RoomController : ControllerBase
         IJoinRoomService joinRoomService,
         ILeaveRoomService leaveRoomService,
         ICloseRoomService closeRoomService,
-        IHeartbeatRoomService heartbeatRoomService
+        IHeartbeatRoomService heartbeatRoomService,
+        IReconnectRoomService reconnectRoomService
         )
     {
         _createRoomService = createRoomService;
@@ -37,6 +39,7 @@ public class RoomController : ControllerBase
         _leaveRoomService = leaveRoomService;
         _closeRoomService = closeRoomService;
         _heartbeatRoomService = heartbeatRoomService;
+        _reconnectRoomService = reconnectRoomService;
     }
 
     [SessionAuthorize]
@@ -136,6 +139,18 @@ public class RoomController : ControllerBase
         await _heartbeatRoomService.ExecuteAsync(new HeartbeatRoomCommand(roomCode, User.GetSteamId()), ct);
 
         return CommonApiResponse.Success("하트비트가 갱신되었습니다.");
+    }
+
+    [SessionAuthorize]
+    [HttpPost("{roomCode}/reconnect")]
+    public async Task<CommonApiResponse<ReconnectRoomResponse>> Reconnect(
+        [FromRoute] string roomCode,
+        CancellationToken ct
+        )
+    {
+        var result = await _reconnectRoomService.ExecuteAsync(new ReconnectRoomCommand(roomCode, User.GetSteamId()), ct);
+
+        return CommonApiResponse.Success("재접속했습니다.", new ReconnectRoomResponse(result.SteamLobbyId, result.Role));
     }
 
     private static GetRoomResponse ToGetRoomResponse(GetRoomResult result) =>

--- a/PushAndPull/PushAndPull/Domain/Room/Dto/Response/ReconnectRoomResponse.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Dto/Response/ReconnectRoomResponse.cs
@@ -1,0 +1,6 @@
+namespace PushAndPull.Domain.Room.Dto.Response;
+
+public record ReconnectRoomResponse(
+    ulong SteamLobbyId,
+    string Role
+    );

--- a/PushAndPull/PushAndPull/Domain/Room/Entity/Config/RoomConfig.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Entity/Config/RoomConfig.cs
@@ -88,6 +88,10 @@ public class RoomConfig : IEntityTypeConfiguration<Room>
             .HasColumnName("last_heartbeat_at")
             .HasColumnType("timestamptz");
 
+        builder.Property(x => x.GuestLastHeartbeatAt)
+            .HasColumnName("guest_last_heartbeat_at")
+            .HasColumnType("timestamptz");
+
         builder.HasOne(r => r.Host)
             .WithMany()
             .HasForeignKey(r => r.HostSteamId)

--- a/PushAndPull/PushAndPull/Domain/Room/Entity/Room.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Entity/Room.cs
@@ -23,6 +23,7 @@ public class Room
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? ExpiresAt { get; private set; }
     public DateTimeOffset? LastHeartbeatAt { get; private set; }
+    public DateTimeOffset? GuestLastHeartbeatAt { get; private set; }
 
     private const int DefaultMaxPlayers = 2;
 

--- a/PushAndPull/PushAndPull/Domain/Room/Repository/Interface/IRoomRepository.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Repository/Interface/IRoomRepository.cs
@@ -10,6 +10,7 @@ public interface IRoomRepository
     Task<bool> TryJoinAsync(string roomCode, ulong steamId, CancellationToken ct = default);
     Task<bool> TryRemoveGuestAsync(string roomCode, ulong steamId, CancellationToken ct = default);
     Task CloseAsync(string roomCode, CancellationToken ct = default);
-    Task<bool> UpdateHeartbeatAsync(string roomCode, ulong hostSteamId, DateTimeOffset now, CancellationToken ct = default);
+    Task<bool> UpdateHeartbeatAsync(string roomCode, ulong steamId, DateTimeOffset now, CancellationToken ct = default);
     Task<int> CloseStaleRoomsAsync(DateTimeOffset cutoff, CancellationToken ct = default);
+    Task<int> FreeStaleGuestsAsync(DateTimeOffset cutoff, CancellationToken ct = default);
 }

--- a/PushAndPull/PushAndPull/Domain/Room/Repository/RoomRepository.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Repository/RoomRepository.cs
@@ -60,7 +60,8 @@ public class RoomRepository : IRoomRepository
                         && x.HostSteamId != steamId)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.CurrentPlayers, x => x.CurrentPlayers + 1)
-                .SetProperty(x => x.GuestSteamId, steamId), ct);
+                .SetProperty(x => x.GuestSteamId, steamId)
+                .SetProperty(x => x.GuestLastHeartbeatAt, DateTimeOffset.UtcNow), ct);
 
         return updated > 0;
     }
@@ -73,7 +74,8 @@ public class RoomRepository : IRoomRepository
                         && x.CurrentPlayers > 1)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.CurrentPlayers, x => x.CurrentPlayers - 1)
-                .SetProperty(x => x.GuestSteamId, (ulong?)null), ct);
+                .SetProperty(x => x.GuestSteamId, (ulong?)null)
+                .SetProperty(x => x.GuestLastHeartbeatAt, (DateTimeOffset?)null), ct);
 
         return updated > 0;
     }
@@ -87,14 +89,15 @@ public class RoomRepository : IRoomRepository
                 .SetProperty(x => x.ExpiresAt, DateTimeOffset.UtcNow), ct);
     }
 
-    public async Task<bool> UpdateHeartbeatAsync(string roomCode, ulong hostSteamId, DateTimeOffset now, CancellationToken ct = default)
+    public async Task<bool> UpdateHeartbeatAsync(string roomCode, ulong steamId, DateTimeOffset now, CancellationToken ct = default)
     {
         var updated = await _context.Rooms
             .Where(x => x.RoomCode == roomCode
-                        && x.HostSteamId == hostSteamId
-                        && x.Status == RoomStatus.Active)
+                        && x.Status == RoomStatus.Active
+                        && (x.HostSteamId == steamId || x.GuestSteamId == steamId))
             .ExecuteUpdateAsync(s => s
-                .SetProperty(x => x.LastHeartbeatAt, now), ct);
+                .SetProperty(x => x.LastHeartbeatAt, x => x.HostSteamId == steamId ? now : x.LastHeartbeatAt)
+                .SetProperty(x => x.GuestLastHeartbeatAt, x => x.GuestSteamId == steamId ? now : x.GuestLastHeartbeatAt), ct);
 
         return updated > 0;
     }
@@ -107,5 +110,17 @@ public class RoomRepository : IRoomRepository
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.Status, RoomStatus.Closed)
                 .SetProperty(x => x.ExpiresAt, DateTimeOffset.UtcNow), ct);
+    }
+
+    public async Task<int> FreeStaleGuestsAsync(DateTimeOffset cutoff, CancellationToken ct = default)
+    {
+        return await _context.Rooms
+            .Where(x => x.Status == RoomStatus.Active
+                        && x.GuestSteamId != null
+                        && (x.GuestLastHeartbeatAt ?? x.CreatedAt) < cutoff)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(x => x.CurrentPlayers, x => x.CurrentPlayers - 1)
+                .SetProperty(x => x.GuestSteamId, (ulong?)null)
+                .SetProperty(x => x.GuestLastHeartbeatAt, (DateTimeOffset?)null), ct);
     }
 }

--- a/PushAndPull/PushAndPull/Domain/Room/Repository/RoomRepository.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Repository/RoomRepository.cs
@@ -117,7 +117,7 @@ public class RoomRepository : IRoomRepository
         return await _context.Rooms
             .Where(x => x.Status == RoomStatus.Active
                         && x.GuestSteamId != null
-                        && (x.GuestLastHeartbeatAt ?? x.CreatedAt) < cutoff)
+                        && (x.GuestLastHeartbeatAt ?? x.LastHeartbeatAt ?? x.CreatedAt) < cutoff)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(x => x.CurrentPlayers, x => x.CurrentPlayers - 1)
                 .SetProperty(x => x.GuestSteamId, (ulong?)null)

--- a/PushAndPull/PushAndPull/Domain/Room/Service/HeartbeatRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/HeartbeatRoomService.cs
@@ -29,8 +29,8 @@ public class HeartbeatRoomService : IHeartbeatRoomService
             var room = await _roomRepository.GetAsync(request.RoomCode, ct);
             if (room == null)
                 throw new RoomNotFoundException(request.RoomCode);
-            if (room.HostSteamId != request.SteamId)
-                throw new NotRoomHostException(request.RoomCode);
+            if (room.HostSteamId != request.SteamId && room.GuestSteamId != request.SteamId)
+                throw new RoomNotParticipantException(request.RoomCode);
 
             throw new RoomNotActiveException(request.RoomCode);
         }

--- a/PushAndPull/PushAndPull/Domain/Room/Service/Interface/IReconnectRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/Interface/IReconnectRoomService.cs
@@ -1,0 +1,16 @@
+namespace PushAndPull.Domain.Room.Service.Interface;
+
+public interface IReconnectRoomService
+{
+    Task<ReconnectRoomResult> ExecuteAsync(ReconnectRoomCommand request, CancellationToken ct = default);
+}
+
+public record ReconnectRoomCommand(
+    string RoomCode,
+    ulong SteamId
+    );
+
+public record ReconnectRoomResult(
+    ulong SteamLobbyId,
+    string Role
+    );

--- a/PushAndPull/PushAndPull/Domain/Room/Service/ReconnectRoomService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/ReconnectRoomService.cs
@@ -1,0 +1,52 @@
+using PushAndPull.Domain.Room.Entity;
+using PushAndPull.Domain.Room.Exception;
+using PushAndPull.Domain.Room.Repository.Interface;
+using PushAndPull.Domain.Room.Service.Interface;
+
+namespace PushAndPull.Domain.Room.Service;
+
+public class ReconnectRoomService : IReconnectRoomService
+{
+    private readonly IRoomRepository _roomRepository;
+    private readonly TimeProvider _timeProvider;
+
+    public ReconnectRoomService(
+        IRoomRepository roomRepository,
+        TimeProvider timeProvider
+        )
+    {
+        _roomRepository = roomRepository;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<ReconnectRoomResult> ExecuteAsync(ReconnectRoomCommand request, CancellationToken ct = default)
+    {
+        var room = await _roomRepository.GetAsync(request.RoomCode, ct)
+            ?? throw new RoomNotFoundException(request.RoomCode);
+
+        if (room.Status != RoomStatus.Active)
+            throw new RoomNotActiveException(request.RoomCode);
+
+        var isHost = room.HostSteamId == request.SteamId;
+        var isGuest = room.GuestSteamId == request.SteamId;
+        if (!isHost && !isGuest)
+            throw new RoomNotParticipantException(request.RoomCode);
+
+        // 유예 시계를 리셋해 곧 있을 cleanup sweep과의 레이스를 막는다.
+        var now = _timeProvider.GetUtcNow();
+        var success = await _roomRepository.UpdateHeartbeatAsync(request.RoomCode, request.SteamId, now, ct);
+        if (!success)
+        {
+            // Get~Update 사이 레이스: sweep가 게스트 슬롯을 해제했거나 방이 닫혔다.
+            var roomAfterAttempt = await _roomRepository.GetAsync(request.RoomCode, ct);
+            if (roomAfterAttempt == null)
+                throw new RoomNotFoundException(request.RoomCode);
+            if (roomAfterAttempt.Status != RoomStatus.Active)
+                throw new RoomNotActiveException(request.RoomCode);
+
+            throw new RoomNotParticipantException(request.RoomCode);
+        }
+
+        return new ReconnectRoomResult(room.SteamLobbyId, isHost ? "Host" : "Guest");
+    }
+}

--- a/PushAndPull/PushAndPull/Domain/Room/Service/StaleRoomCleanupService.cs
+++ b/PushAndPull/PushAndPull/Domain/Room/Service/StaleRoomCleanupService.cs
@@ -57,5 +57,9 @@ public class StaleRoomCleanupService : BackgroundService
         var closed = await roomRepository.CloseStaleRoomsAsync(cutoff, ct);
         if (closed > 0)
             _logger.LogInformation("Closed {Count} stale rooms", closed);
+
+        var freed = await roomRepository.FreeStaleGuestsAsync(cutoff, ct);
+        if (freed > 0)
+            _logger.LogInformation("Freed {Count} stale guest slots", freed);
     }
 }

--- a/PushAndPull/PushAndPull/Migrations/20260618003600_AddGuestLastHeartbeatAt.Designer.cs
+++ b/PushAndPull/PushAndPull/Migrations/20260618003600_AddGuestLastHeartbeatAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PushAndPull.Global.Infrastructure;
@@ -11,9 +12,11 @@ using PushAndPull.Global.Infrastructure;
 namespace PushAndPull.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618003600_AddGuestLastHeartbeatAt")]
+    partial class AddGuestLastHeartbeatAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PushAndPull/PushAndPull/Migrations/20260618003600_AddGuestLastHeartbeatAt.cs
+++ b/PushAndPull/PushAndPull/Migrations/20260618003600_AddGuestLastHeartbeatAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PushAndPull.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGuestLastHeartbeatAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "guest_last_heartbeat_at",
+                schema: "room",
+                table: "room",
+                type: "timestamptz",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "guest_last_heartbeat_at",
+                schema: "room",
+                table: "room");
+        }
+    }
+}


### PR DESCRIPTION
## 개요

끊긴 플레이어가 방에 다시 접속할 수 있는 재접속 기능을 추가하였습니다. 아울러 게스트의 하트비트를 호스트와 동일하게 추적하여, 일정 시간 응답이 없는 게스트의 슬롯을 자동으로 정리하도록 하였습니다.

## 변경 사항

### 재접속 기능
- `POST /room/{roomCode}/reconnect` 엔드포인트를 추가하였습니다. 호출자가 호스트/게스트인지 확인한 뒤 `SteamLobbyId`와 역할(`Host`/`Guest`)을 반환합니다.
- 재접속 시 하트비트를 즉시 갱신하여, 곧 실행될 정리 sweep과의 레이스를 방지하도록 하였습니다.
- `GetAsync`와 `UpdateHeartbeatAsync` 사이의 레이스(게스트 슬롯 해제, 방 종료)를 재조회로 감지하여 적절한 예외를 던지도록 하였습니다.

### 게스트 하트비트 추적
- `Room` 엔티티에 `GuestLastHeartbeatAt` 컬럼을 추가하고 마이그레이션(`AddGuestLastHeartbeatAt`)을 생성하였습니다.
- `UpdateHeartbeatAsync`가 호스트뿐 아니라 게스트의 하트비트도 갱신하도록 변경하였습니다. 비참여자 요청 시 `NotRoomHostException` 대신 `RoomNotParticipantException`을 던지도록 하였습니다.
- 입장 시 `GuestLastHeartbeatAt`을 설정하고, 퇴장 시 초기화하도록 하였습니다.

### 비활성 게스트 정리
- `FreeStaleGuestsAsync`를 추가하여, 하트비트 타임아웃을 초과한 게스트 슬롯을 정리 sweep에서 자동으로 해제하도록 하였습니다.

## 테스트
- 재접속 서비스 단위 테스트(`ReconnectRoomServiceTests`)를 추가하였습니다. 호스트/게스트 재접속, 미존재 방, 비활성 방, 비참여자, 레이스 상황을 검증합니다.
- 하트비트/정리 서비스 테스트를 게스트 시나리오에 맞춰 갱신하였습니다.

## 기타
- 마이그레이션 생성을 표준화하기 위해 `db-migrate` 스킬과 관련 규칙을 추가하였습니다.
