### PR TITLE
[global] stage 연결문자열 인용 및 CD 실패 은폐 방지

### DIFF
--- a/.github/workflows/pushandpull-prod-cd.yml
+++ b/.github/workflows/pushandpull-prod-cd.yml
@@ -87,6 +87,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           fingerprint: ${{ secrets.SSH_FINGERPRINT }}
           script: |
+            set -euo pipefail
             mkdir -p ~/deploy
 
             printf 'DB_CONNECTION_STRING=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\n' \

--- a/.github/workflows/pushandpull-stage-cd.yml
+++ b/.github/workflows/pushandpull-stage-cd.yml
@@ -51,6 +51,7 @@ jobs:
           key: ${{ secrets.STAGE_SSH_PRIVATE_KEY }}
           fingerprint: ${{ secrets.STAGE_SSH_FINGERPRINT }}
           script: |
+            set -euo pipefail
             mkdir -p ~/deploy
 
             printf 'POSTGRES_DB=%s\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\n' \

--- a/.github/workflows/pushandpull-stage-ci.yml
+++ b/.github/workflows/pushandpull-stage-ci.yml
@@ -44,7 +44,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     needs: [validate-title]
-    if: always() && (needs.validate-title.result == 'success' || needs.validate-title.result == 'skipped')
+    if: >-
+      always()
+      && (needs.validate-title.result == 'success' || needs.validate-title.result == 'skipped')
+      && (github.event.action != 'edited' || github.event.changes.base != null)
 
     env:
       SOLUTION: PushAndPull/PushAndPull.sln

--- a/PushAndPull/deploy/compose.stage.yaml
+++ b/PushAndPull/deploy/compose.stage.yaml
@@ -29,7 +29,7 @@ services:
       - "80:80"
     environment:
       - ASPNETCORE_ENVIRONMENT=Staging
-      - ConnectionStrings__Default=Host=pushandpull-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
+      - ConnectionStrings__Default=Host=pushandpull-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password='${POSTGRES_PASSWORD}'
     depends_on:
       pushandpull-db:
         condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -50,6 +50,8 @@ docker volume create pushandpull-stage-postgres-data
 
 (호스트 경로로 직접 관리하려면 `-v /data/postgres:/var/lib/postgresql/data` 같은 bind mount로 대체할 수도 있다.)
 
+> ⚠️ stage 서버의 연결 문자열은 `compose.stage.yaml`에서 `STAGE_POSTGRES_PASSWORD`로 조립되며 값은 싱글쿼트로 인용된다(`Password='...'`). 덕분에 `;`·`=`·공백은 안전하지만, **비밀번호에 싱글쿼트(`'`)는 넣지 말 것**. Npgsql 연결 문자열 파서가 인용을 조기에 닫아 인증에 실패한다(굳이 쓰려면 `''`로 이스케이프). prod는 `DB_CONNECTION_STRING`을 통째로 주입하므로 이 제약이 없다.
+
 ## Swagger 노출 정책
 
 `Program.cs`에서 환경에 따라 게이팅한다.


### PR DESCRIPTION
## 개요

#46 머지 이후 ultrareview가 찾아낸 배포 안정성 이슈 3건을 develop에 반영하였습니다. #46은 해당 수정 적용 전에 머지되어, 수정 커밋이 develop에 들어가지 못한 상태였습니다.

## 변경 사항

### 1. stage 연결 문자열 비밀번호 인용 (normal)
`compose.stage.yaml`에서 `Password=${POSTGRES_PASSWORD}`를 인용하지 않아, `;` 등 Npgsql 특수문자가 포함된 비밀번호가 키/값 구분자로 잘려 인증에 실패할 수 있었습니다. DB 컨테이너는 전체 비밀번호로 기동되어 healthy하지만 서버만 연결 실패하는 함정이 있었습니다. `Password='${POSTGRES_PASSWORD}'`로 인용하여 해결하였습니다.

### 2. CD 배포 스크립트 fail-fast 적용 (normal)
`pushandpull-stage-cd.yml` / `pushandpull-prod-cd.yml`의 SSH 배포 스크립트가 `set -e` 없이 실행되어, `docker compose pull` 실패 후에도 옛 이미지로 `up -d`가 진행되고 마지막 `docker logs`가 exit 0이라 배포 성공으로 오보될 수 있었습니다. 스크립트 첫 줄에 `set -euo pipefail`을 추가하여 중간 실패 시 즉시 중단되도록 하였습니다.

### 3. build-and-test 재실행 게이트 (nit)
앞서 추가한 PR 제목 검증용 `edited` 트리거 때문에, PR 제목/본문만 수정해도 build-and-test가 매번 재실행되었습니다. `github.event.action != 'edited' || github.event.changes.base != null` 조건을 추가하여 제목/본문 편집에는 빌드/테스트가 돌지 않도록 하였습니다.

## 검증

- `docker compose config`로 `;` 포함 비밀번호가 인용 내부에 온전히 보존됨을 확인하였습니다.
- 워크플로우/compose YAML 파싱 정상을 확인하였습니다.
