### PR TITLE
[ci] Steam 시크릿 참조를 STEAM_API_KEY로 정정

### DIFF
--- a/.github/workflows/pushandpull-prod-cd.yml
+++ b/.github/workflows/pushandpull-prod-cd.yml
@@ -92,7 +92,7 @@ jobs:
 
             printf 'DB_CONNECTION_STRING=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\n' \
               "${{ secrets.DB_CONNECTION_STRING }}" \
-              "${{ secrets.STEAM_WEB_API_KEY }}" \
+              "${{ secrets.STEAM_API_KEY }}" \
               "${{ secrets.STEAM_APP_ID }}" \
               > ~/deploy/.env
 

--- a/.github/workflows/pushandpull-stage-cd.yml
+++ b/.github/workflows/pushandpull-stage-cd.yml
@@ -58,7 +58,7 @@ jobs:
               "${{ secrets.STAGE_POSTGRES_DB }}" \
               "${{ secrets.STAGE_POSTGRES_USER }}" \
               "${{ secrets.STAGE_POSTGRES_PASSWORD }}" \
-              "${{ secrets.STEAM_WEB_API_KEY }}" \
+              "${{ secrets.STEAM_API_KEY }}" \
               "${{ secrets.STEAM_APP_ID }}" \
               > ~/deploy/.env
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,7 +114,7 @@ prod/stage 모두 `deploy/prod.dockerfile`로 빌드한다.
 ### 공통
 - `DOCKER_USERNAME`, `DOCKER_PASSWORD`
 - `DISCORD_WEBHOOK`
-- `STEAM_WEB_API_KEY`, `STEAM_APP_ID` — prod·stage 공용
+- `STEAM_API_KEY`, `STEAM_APP_ID` — prod·stage 공용
 
 ### prod (`pushandpull-prod-cd.yml`)
 - `SSH_HOST`, `SSH_USERNAME`, `SSH_PORT`, `SSH_PRIVATE_KEY`
@@ -126,7 +126,7 @@ prod/stage 모두 `deploy/prod.dockerfile`로 빌드한다.
 - `STAGE_SSH_FINGERPRINT` — 서버 호스트 키 SHA256 지문 (MITM 방지)
 - `STAGE_POSTGRES_DB`, `STAGE_POSTGRES_USER`, `STAGE_POSTGRES_PASSWORD` — in-compose DB 컨테이너 자격증명
 
-> Steam 키(`STEAM_WEB_API_KEY`, `STEAM_APP_ID`)는 prod·stage 공용이라 공통 섹션에서 한 번만 등록한다.
+> Steam 키(`STEAM_API_KEY`, `STEAM_APP_ID`)는 prod·stage 공용이라 공통 섹션에서 한 번만 등록한다.
 
 > Redis는 내부 컨테이너(고정 주소)라 시크릿이 없다.
 


### PR DESCRIPTION
## 개요

prod·stage CD 워크플로가 존재하지 않는 `STEAM_WEB_API_KEY` 시크릿을 참조하여, 배포 시 생성되는 `.env`의 Steam 키 값이 빈 문자열로 기록되던 문제를 수정하였습니다. 실제 등록된 시크릿 이름은 `STEAM_API_KEY`입니다.

## 변경 사항

- `pushandpull-stage-cd.yml`: `.env` 생성 시 Steam 키 시크릿 참조를 `STEAM_API_KEY`로 정정하였습니다.
- `pushandpull-prod-cd.yml`: 동일한 시크릿 참조를 `STEAM_API_KEY`로 정정하였습니다.
- `docs/deployment.md`: 필요한 GitHub Secrets 목록과 공용 등록 안내의 시크릿 이름 표기를 `STEAM_API_KEY`로 정정하였습니다.

## 참고

- `.env`의 변수 이름(`STEAM_WEB_API_KEY`)은 `compose.yaml`의 `Steam__WebApiKey=${STEAM_WEB_API_KEY}` 매핑이 의존하므로 그대로 유지하였습니다. 즉 시크릿 이름(`STEAM_API_KEY`)과 환경변수 이름(`STEAM_WEB_API_KEY`)이 서로 다른 점만 정정 대상이었습니다.

## 영향

- 배포 시 컨테이너에 Steam Web API 키가 정상 주입되어, 비어 있던 키로 인한 런타임 인증 실패 가능성이 해소되었습니다.
