### PR TITLE
[global] 배포 문서 fingerprint 가이드를 ECDSA로 수정

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -130,10 +130,10 @@ prod/stage 모두 `deploy/prod.dockerfile`로 빌드한다.
 
 > Redis는 내부 컨테이너(고정 주소)라 시크릿이 없다.
 
-호스트 키 지문(`*_SSH_FINGERPRINT`)은 배포 대상 서버에서 아래로 얻는다:
+호스트 키 지문(`*_SSH_FINGERPRINT`)은 배포 대상 서버에서 아래로 얻는다. appleboy/scp-action·ssh-action(Go `x/crypto/ssh`)은 호스트 키 협상 시 ECDSA를 ED25519보다 우선하므로 **ECDSA 키 지문**을 등록해야 한다. ED25519 지문을 넣으면 `ssh: handshake failed: host key fingerprint mismatch`로 실패한다.
 
 ```bash
-ssh-keyscan -t ed25519 <host> | ssh-keygen -lf - | awk '{print $2}'
+ssh-keyscan -p <port> -t ecdsa <host> | ssh-keygen -lf - | awk '{print $2}'
 # 예: SHA256:abc123...  (이 값 전체를 시크릿에 등록)
 ```
 


### PR DESCRIPTION
## 개요

배포 문서의 호스트 키 지문 조회 가이드가 ED25519 기준으로 작성되어 있어, 그대로 따르면 stage·prod CD가 `host key fingerprint mismatch`로 실패하던 문제를 정정하였습니다.

## 배경

appleboy/scp-action·ssh-action은 Go `x/crypto/ssh`를 사용하며, 호스트 키 협상 시 ECDSA를 ED25519보다 우선합니다. 따라서 `*_SSH_FINGERPRINT` 시크릿에는 서버의 ECDSA 호스트 키 지문을 등록해야 하는데, 기존 문서는 `ssh-keyscan -t ed25519`로 안내하고 있어 실제 stage 배포에서 fingerprint mismatch가 발생하였습니다.

## 변경 사항

- `docs/deployment.md`: 호스트 키 지문 가이드를 ECDSA 기준으로 수정하였습니다. ECDSA를 등록해야 하는 이유와 ED25519 사용 시 실패 메시지를 함께 명시하였고, 비표준 포트 대응을 위해 `-p <port>` 옵션도 반영하였습니다.

## 비고

- 문서만 수정하였으며 코드·워크플로 변경은 없습니다.
