### PR TITLE
[ci] 문서 전용 변경 시 CD 미실행 (paths-ignore)

### DIFF
--- a/.github/workflows/pushandpull-prod-cd.yml
+++ b/.github/workflows/pushandpull-prod-cd.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pushandpull-stage-cd.yml
+++ b/.github/workflows/pushandpull-stage-cd.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 개요

문서·설정 등 배포와 무관한 파일만 변경된 PR이 `develop`/`main`에 머지될 때, 불필요하게 CD(빌드·배포·알림)가 실행되던 동작을 개선하였습니다. push 트리거에 `paths-ignore`를 추가하여 해당 경로만 변경된 경우 워크플로 자체가 실행되지 않도록 하였습니다.

## 변경 사항

- `pushandpull-stage-cd.yml`(develop), `pushandpull-prod-cd.yml`(main) 두 워크플로의 push 트리거에 동일한 `paths-ignore`를 추가하였습니다.

```yaml
paths-ignore:
  - 'docs/**'
  - '**/*.md'
  - '.claude/**'
```

## 동작 방식

- GitHub은 push의 `before…after` diff(=PR 전체 변경)로 판단하므로, 머지 커밋·스쿼시 모두 정상 동작합니다.
- 위 경로만 변경된 경우 → CD 미실행(잡·Discord 알림 모두 생략).
- 코드와 문서가 함께 변경된 경우 → 코드 변경이 diff에 포함되어 정상적으로 CD가 실행됩니다.
- `compose.yaml`·`Dockerfile`·워크플로 yml 등은 ignore 대상이 아니므로 변경 시 그대로 배포를 트리거합니다.

## 비고

- 경로 기반(denylist) 방식이라 배포와 무관한 디렉터리가 새로 생기면 목록에 추가하면 됩니다.
- 검증: 머지 후 docs 전용 PR로 CD가 건너뛰어지는지 한 번 확인하는 것을 권장합니다.
