### PR TITLE
[global] Gamism SDK 0.3.2로 Swagger 응답 스키마 정상화

### DIFF
--- a/PushAndPull/CLAUDE.md
+++ b/PushAndPull/CLAUDE.md
@@ -28,7 +28,7 @@
 | `Microsoft.Extensions.Caching.StackExchangeRedis` | 9.0.3 | `/stackexchange/stackexchange.redis` |
 | `Dapper` | 2.1.66 | `/dotnet/docs` |
 | `BCrypt.Net-Next` | 4.0.3 | — (no Context7 entry) |
-| `Gamism.SDK.Extensions.AspNetCore` | 0.2.8 | — (no Context7 entry) |
+| `Gamism.SDK.Extensions.AspNetCore` | 0.3.2 | — (no Context7 entry) |
 | `xunit` | 2.9.2 | `/xunit/xunit.net` |
 | `Moq` | 4.20.72 | — (no Context7 entry) |
 

--- a/PushAndPull/PushAndPull/PushAndPull.csproj
+++ b/PushAndPull/PushAndPull/PushAndPull.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
 <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Dapper" Version="2.1.66" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.2.8" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.12" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## 개요

`Gamism.SDK.Extensions.AspNetCore`를 `0.2.8`에서 `0.3.2`로 업그레이드하였습니다. 기존 버전에서 Swagger 응답 스키마가 `CommonApiResponse<T>` 래핑을 제대로 반영하지 못하던 문제를 해결하였습니다.

## 변경 사항

- `PushAndPull.csproj`의 `Gamism.SDK.Extensions.AspNetCore` 버전을 `0.2.8` → `0.3.2`로 상향하였습니다.
- 기술 스택 문서(`PushAndPull/CLAUDE.md`)의 버전 표기를 `0.3.2`로 갱신하였습니다.

## 검증

- 패키지 복원 및 솔루션 빌드가 오류 없이 완료되었습니다.
- 단위 테스트 103개가 모두 통과하였습니다.
- 로컬에서 Postgres/Redis 컨테이너를 띄워 런타임 스모크 테스트를 수행하였습니다.
  - 앱이 정상 기동하고 EF Core 마이그레이션이 적용되었습니다.
  - `/swagger/v1/swagger.json`이 HTTP 200으로 정상 제공되었습니다.
  - 각 엔드포인트 200 응답이 `CommonApiResponse<T>` 형태(`status`, `code`, `message`, `data`)로 정확히 생성됨을 확인하였습니다.

## 영향

- 코드에서 사용하는 SDK API 표면(`AddGamismSdk`/`UseGamismSdk`, `Gamism.SDK.Core.Network`, `Exceptions`)에 영향을 주는 호환성 변경은 없습니다.
- 두 SDK 패키지 모두 EF Core에 의존하지 않으므로 기존 의존성 구성에 변동이 없습니다.
