### PR TITLE
[auth] 회로 차단기 테스트 간헐적 CI 실패 수정

### DIFF
--- a/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
+++ b/PushAndPull/PushAndPull.Test/Service/Auth/SteamCircuitBreakerTests.cs
@@ -16,6 +16,8 @@ namespace PushAndPull.Test.Service.Auth;
 
 public class SteamCircuitBreakerTests
 {
+    private const string ResilienceCollection = "SteamResiliencePipeline";
+
     private static IConfiguration BuildConfig(int minimumThroughput = 2, int timeoutSeconds = 5)
         => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -51,6 +53,11 @@ public class SteamCircuitBreakerTests
     private static HttpResponseMessage ServerError()
         => new(HttpStatusCode.InternalServerError);
 
+    // Classes that build the real HttpClient resilience pipeline share one collection so
+    // they never run in parallel. Concurrent first-time DataAnnotations validation of the
+    // pipeline's TimeSpan options ([Range(typeof(TimeSpan), ...)]) is not thread-safe and
+    // intermittently throws InvalidCastException (TimeSpan -> String).
+    [Collection(ResilienceCollection)]
     public class WhenFailuresBelowThreshold
     {
         [Fact]
@@ -70,6 +77,7 @@ public class SteamCircuitBreakerTests
         }
     }
 
+    [Collection(ResilienceCollection)]
     public class WhenFailureRatioExceeded
     {
         [Fact]
@@ -90,6 +98,7 @@ public class SteamCircuitBreakerTests
         }
     }
 
+    [Collection(ResilienceCollection)]
     public class WhenCircuitOpenAndBreakDurationElapsed
     {
         [Fact]
@@ -116,6 +125,7 @@ public class SteamCircuitBreakerTests
         }
     }
 
+    [Collection(ResilienceCollection)]
     public class WhenSteamApiHangs
     {
         [Fact]


### PR DESCRIPTION
## 개요

develop에서 `SteamCircuitBreakerTests`가 간헐적으로 실패하여 CI(`pushandpull stage CI`)가 빨간 상태가 되던 문제를 수정하였습니다. 동일 커밋이 PR 브랜치에서는 통과하고 develop 머지 런에서만 1개 테스트가 실패하던 전형적인 flaky 현상이었습니다.

## 변경 사항

- `SteamCircuitBreakerTests`에서 실제 HttpClient resilience 파이프라인을 빌드하는 4개 nested 클래스(`WhenFailuresBelowThreshold`, `WhenFailureRatioExceeded`, `WhenCircuitOpenAndBreakDurationElapsed`, `WhenSteamApiHangs`)를 동일한 xUnit `[Collection]`으로 묶어, 서로 병렬 실행되지 않도록 하였습니다.
- 비-자명한 변경이므로 의도를 주석으로 남겼습니다.

## 원인

- resilience 파이프라인의 timeout/circuit-breaker 옵션은 첫 요청 시점에 `[Range(typeof(TimeSpan), ...)]` 기반 DataAnnotations 검증을 수행합니다.
- `RangeAttribute`의 TimeSpan 변환 초기화는 스레드 안전하지 않아, 여러 테스트 클래스가 동시에 처음 검증을 수행하면 값을 String으로 캐스팅하려다 `InvalidCastException: Unable to cast 'System.TimeSpan' to 'System.String'`이 간헐적으로 발생하였습니다.
- 실제 파이프라인을 빌드하는 테스트가 이 파일에만 있어, 해당 클래스들을 직렬화하면 동시 최초 검증 자체가 사라집니다.

## 검증

- 솔루션 빌드 성공(오류 0개).
- 전체 단위 테스트 103개를 4회 연속 실행하여 모두 통과하였습니다.
- 다만 이 실패는 로컬에서 수정 전에도 재현되지 않던 동시성 문제이므로, 통과 기록 자체가 직접 증명은 아닙니다. 근본 근거는 xUnit collection 직렬화로 동시 검증을 구조적으로 차단했다는 점입니다.

## 영향

- 테스트 코드만 변경하였으며 프로덕션 코드 변경은 없습니다.
- 해당 클래스들이 직렬 실행되나, 전체 테스트 수행 시간에 유의미한 차이는 없습니다(전체 약 2초).
