### PR TITLE
[global] Swagger API 문서화와 인증 응답 코드 개선

### DIFF
--- a/src/PushAndPull.Test/Domain/Auth/Exception/SteamAuthExceptionTests.cs
+++ b/src/PushAndPull.Test/Domain/Auth/Exception/SteamAuthExceptionTests.cs
@@ -43,6 +43,12 @@ public class SteamAuthExceptionTests
         {
             Assert.Equal(HttpStatusCode.Forbidden, new PublisherBannedException(7UL).StatusCode);
         }
+
+        [Fact]
+        public void It_PreservesTheSteamId()
+        {
+            Assert.Equal(7UL, new PublisherBannedException(7UL).SteamId);
+        }
     }
 
     public class WhenAFamilySharingNotAllowedExceptionIsCreated
@@ -51,6 +57,12 @@ public class SteamAuthExceptionTests
         public void It_MapsToForbidden()
         {
             Assert.Equal(HttpStatusCode.Forbidden, new FamilySharingNotAllowedException(7UL).StatusCode);
+        }
+
+        [Fact]
+        public void It_PreservesTheSteamId()
+        {
+            Assert.Equal(7UL, new FamilySharingNotAllowedException(7UL).SteamId);
         }
     }
 

--- a/src/PushAndPull.Test/Domain/Auth/Exception/SteamAuthExceptionTests.cs
+++ b/src/PushAndPull.Test/Domain/Auth/Exception/SteamAuthExceptionTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using Gamism.SDK.Extensions.AspNetCore.Exceptions;
+using PushAndPull.Domain.Auth.Exception;
+
+namespace PushAndPull.Test.Domain.Auth.Exception;
+
+public class SteamAuthExceptionTests
+{
+    public class WhenAnInvalidTicketExceptionIsCreated
+    {
+        [Fact]
+        public void It_IsAnExpectedException()
+        {
+            Assert.IsAssignableFrom<ExpectedException>(new InvalidTicketException());
+        }
+
+        [Fact]
+        public void It_MapsToUnauthorized()
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, new InvalidTicketException().StatusCode);
+        }
+    }
+
+    public class WhenAVacBannedExceptionIsCreated
+    {
+        [Fact]
+        public void It_MapsToForbidden()
+        {
+            Assert.Equal(HttpStatusCode.Forbidden, new VacBannedException(7UL).StatusCode);
+        }
+
+        [Fact]
+        public void It_PreservesTheSteamId()
+        {
+            Assert.Equal(7UL, new VacBannedException(7UL).SteamId);
+        }
+    }
+
+    public class WhenAPublisherBannedExceptionIsCreated
+    {
+        [Fact]
+        public void It_MapsToForbidden()
+        {
+            Assert.Equal(HttpStatusCode.Forbidden, new PublisherBannedException(7UL).StatusCode);
+        }
+    }
+
+    public class WhenAFamilySharingNotAllowedExceptionIsCreated
+    {
+        [Fact]
+        public void It_MapsToForbidden()
+        {
+            Assert.Equal(HttpStatusCode.Forbidden, new FamilySharingNotAllowedException(7UL).StatusCode);
+        }
+    }
+
+    public class WhenASteamApiExceptionIsCreated
+    {
+        [Fact]
+        public void It_IsNotAnExpectedException()
+        {
+            Assert.False(typeof(ExpectedException).IsAssignableFrom(typeof(SteamApiException)));
+        }
+    }
+}

--- a/src/PushAndPull/Domain/Auth/Controller/AuthController.cs
+++ b/src/PushAndPull/Domain/Auth/Controller/AuthController.cs
@@ -1,8 +1,11 @@
+using System.Net;
 using Gamism.SDK.Core.Network;
+using Gamism.SDK.Extensions.AspNetCore.Swagger;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using PushAndPull.Domain.Auth.Dto.Request;
 using PushAndPull.Domain.Auth.Dto.Response;
+using PushAndPull.Domain.Auth.Exception;
 using PushAndPull.Domain.Auth.Service.Interface;
 using PushAndPull.Global.Security;
 
@@ -24,6 +27,11 @@ public class AuthController : ControllerBase
         _logoutService = logoutService;
     }
 
+    [ApiDoc("로그인", "스팀 인증 티켓을 검증하고 세션을 발급한다.")]
+    [ApiError(typeof(InvalidNicknameException), "닉네임이 올바르지 않습니다.")]
+    [ApiError(typeof(InvalidTicketException), "스팀 인증 티켓이 유효하지 않습니다.")]
+    [ApiError(HttpStatusCode.Forbidden, "차단되었거나 패밀리 공유 계정은 이용할 수 없습니다.")]
+    [ApiError(HttpStatusCode.ServiceUnavailable, "스팀 인증 서버에 일시적으로 연결할 수 없습니다.")]
     [HttpPost("login")]
     [EnableRateLimiting("login")]
     public async Task<CommonApiResponse<LoginResponse>> Login(
@@ -39,6 +47,8 @@ public class AuthController : ControllerBase
         return CommonApiResponse.Success("로그인되었습니다.", new LoginResponse(result.SessionId));
     }
 
+    [ApiDoc("로그아웃", "현재 세션을 만료시킨다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost("logout")]
     public async Task<CommonApiResponse> Logout(CancellationToken ct)

--- a/src/PushAndPull/Domain/Auth/Exception/FamilySharingNotAllowedException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/FamilySharingNotAllowedException.cs
@@ -1,9 +1,11 @@
+using System.Net;
+
 namespace PushAndPull.Domain.Auth.Exception;
 
 public class FamilySharingNotAllowedException : SteamAuthException
 {
     public FamilySharingNotAllowedException(ulong steamId)
-        : base("Family sharing is not allowed", steamId)
+        : base(HttpStatusCode.Forbidden, "Family sharing is not allowed", steamId)
     {
     }
 }

--- a/src/PushAndPull/Domain/Auth/Exception/InvalidTicketException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/InvalidTicketException.cs
@@ -1,9 +1,11 @@
+using System.Net;
+
 namespace PushAndPull.Domain.Auth.Exception;
 
 public class InvalidTicketException : SteamAuthException
 {
     public InvalidTicketException(string message = "Invalid authentication ticket")
-        : base(message)
+        : base(HttpStatusCode.Unauthorized, message)
     {
     }
 }

--- a/src/PushAndPull/Domain/Auth/Exception/PublisherBannedException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/PublisherBannedException.cs
@@ -1,9 +1,11 @@
+using System.Net;
+
 namespace PushAndPull.Domain.Auth.Exception;
 
 public class PublisherBannedException : SteamAuthException
 {
     public PublisherBannedException(ulong steamId)
-        : base($"User is banned by publisher", steamId)
+        : base(HttpStatusCode.Forbidden, "User is banned by publisher", steamId)
     {
     }
 }

--- a/src/PushAndPull/Domain/Auth/Exception/SteamApiException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/SteamApiException.cs
@@ -1,6 +1,6 @@
 namespace PushAndPull.Domain.Auth.Exception;
 
-public class SteamApiException : SteamAuthException
+public class SteamApiException : System.Exception
 {
     public int? StatusCode { get; }
 

--- a/src/PushAndPull/Domain/Auth/Exception/SteamAuthException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/SteamAuthException.cs
@@ -1,17 +1,14 @@
+using System.Net;
+using Gamism.SDK.Extensions.AspNetCore.Exceptions;
+
 namespace PushAndPull.Domain.Auth.Exception;
 
-public abstract class SteamAuthException : System.Exception
+public abstract class SteamAuthException : ExpectedException
 {
     public ulong SteamId { get; }
 
-    protected SteamAuthException(string message, ulong steamId = 0)
-        : base(message)
-    {
-        SteamId = steamId;
-    }
-
-    protected SteamAuthException(string message, System.Exception innerException, ulong steamId = 0)
-        : base(message, innerException)
+    protected SteamAuthException(HttpStatusCode statusCode, string message, ulong steamId = 0)
+        : base(statusCode, message)
     {
         SteamId = steamId;
     }

--- a/src/PushAndPull/Domain/Auth/Exception/VacBannedException.cs
+++ b/src/PushAndPull/Domain/Auth/Exception/VacBannedException.cs
@@ -1,9 +1,11 @@
+using System.Net;
+
 namespace PushAndPull.Domain.Auth.Exception;
 
 public class VacBannedException : SteamAuthException
 {
     public VacBannedException(ulong steamId)
-        : base($"User is VAC banned", steamId)
+        : base(HttpStatusCode.Forbidden, "User is VAC banned", steamId)
     {
     }
 }

--- a/src/PushAndPull/Domain/Room/Controller/RoomController.cs
+++ b/src/PushAndPull/Domain/Room/Controller/RoomController.cs
@@ -1,8 +1,11 @@
+using System.Net;
 using Gamism.SDK.Core.Network;
+using Gamism.SDK.Extensions.AspNetCore.Swagger;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using PushAndPull.Domain.Room.Dto.Request;
 using PushAndPull.Domain.Room.Dto.Response;
+using PushAndPull.Domain.Room.Exception;
 using PushAndPull.Domain.Room.Service.Interface;
 using PushAndPull.Global.Security;
 
@@ -42,6 +45,9 @@ public class RoomController : ControllerBase
         _reconnectRoomService = reconnectRoomService;
     }
 
+    [ApiDoc("방 생성", "스팀 로비를 기반으로 새 방을 생성한다.")]
+    [ApiError(typeof(InvalidRoomNameException), "방 이름이 올바르지 않습니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost]
     [EnableRateLimiting("create_room")]
@@ -63,6 +69,8 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Created("방이 생성되었습니다.", new CreateRoomResponse(result.RoomCode));
     }
 
+    [ApiDoc("방 조회", "roomCode로 단일 방 정보를 조회한다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
     [HttpGet("{roomCode}")]
     public async Task<CommonApiResponse<GetRoomResponse>> GetRoom(
         [FromRoute] string roomCode,
@@ -74,6 +82,7 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Success("방 조회 성공.", ToGetRoomResponse(result));
     }
 
+    [ApiDoc("방 목록 조회", "페이지네이션으로 공개된 방 목록을 조회한다.")]
     [HttpGet("all")]
     public async Task<CommonApiResponse<GetAllRoomResponse>> GetAllRoom(
         [FromQuery] int page = 1,
@@ -91,6 +100,14 @@ public class RoomController : ControllerBase
             new GetAllRoomResponse(rooms, result.Page, result.Size, result.HasNext));
     }
 
+    [ApiDoc("방 참여", "roomCode와 비밀번호로 방에 참여한다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
+    [ApiError(typeof(RoomNotActiveException), "참여할 수 없는 방 상태입니다.")]
+    [ApiError(typeof(RoomFullException), "방이 가득 찼습니다.")]
+    [ApiError(typeof(AlreadyJoinedRoomException), "이미 참여한 방입니다.")]
+    [ApiError(typeof(PasswordRequiredException), "비밀번호가 필요합니다.")]
+    [ApiError(typeof(InvalidPasswordException), "비밀번호가 올바르지 않습니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost("{roomCode}/join")]
     [EnableRateLimiting("join_room")]
@@ -105,6 +122,11 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Success("방에 참여했습니다.", new JoinRoomResponse(result.SteamLobbyId));
     }
 
+    [ApiDoc("방 나가기", "참여 중인 방에서 나간다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
+    [ApiError(typeof(RoomNotActiveException), "이용할 수 없는 방 상태입니다.")]
+    [ApiError(typeof(RoomNotParticipantException), "방 참여자가 아닙니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost("{roomCode}/leave")]
     public async Task<CommonApiResponse> LeaveRoom(
@@ -117,6 +139,10 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Success("방에서 나갔습니다.");
     }
 
+    [ApiDoc("방 닫기", "방장이 방을 닫는다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
+    [ApiError(typeof(NotRoomHostException), "방장만 방을 닫을 수 있습니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpDelete("{roomCode}")]
     public async Task<CommonApiResponse> CloseRoom(
@@ -129,6 +155,11 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Success("방을 닫았습니다.");
     }
 
+    [ApiDoc("방 하트비트", "참여자의 활성 상태를 갱신해 방 세션을 유지한다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
+    [ApiError(typeof(RoomNotActiveException), "이용할 수 없는 방 상태입니다.")]
+    [ApiError(typeof(RoomNotParticipantException), "방 참여자가 아닙니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost("{roomCode}/heartbeat")]
     public async Task<CommonApiResponse> Heartbeat(
@@ -141,6 +172,11 @@ public class RoomController : ControllerBase
         return CommonApiResponse.Success("하트비트가 갱신되었습니다.");
     }
 
+    [ApiDoc("방 재접속", "끊긴 세션으로 참여 중이던 방에 재접속한다.")]
+    [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
+    [ApiError(typeof(RoomNotActiveException), "이용할 수 없는 방 상태입니다.")]
+    [ApiError(typeof(RoomNotParticipantException), "방 참여자가 아닙니다.")]
+    [ApiError(HttpStatusCode.Unauthorized, "세션이 유효하지 않습니다.")]
     [SessionAuthorize]
     [HttpPost("{roomCode}/reconnect")]
     [EnableRateLimiting("join_room")]

--- a/src/PushAndPull/PushAndPull.csproj
+++ b/src/PushAndPull/PushAndPull.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
 <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Dapper" Version="2.1.66" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.3.2" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.12" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## 개요

Gamism SDK의 `[ApiDoc]`/`[ApiError]` attribute를 활용하여 Swagger 문서에 각 API의 설명과 실패 응답을 노출하였습니다. 더불어 스팀 인증 실패가 일괄적으로 500으로 응답되던 문제를 의미에 맞는 상태 코드로 정비하였습니다.

## 변경 사항

### Swagger 문서화
- `Gamism.SDK.Extensions.AspNetCore` 0.3.2 → 0.4.0 으로 올렸습니다. (신규 `[ApiDoc]`/`[ApiError]` 지원 버전)
- `RoomController`/`AuthController` 전체 엔드포인트에 `[ApiDoc]` 요약·설명과 `[ApiError]` 실패 응답을 추가하였습니다.
- 동일 상태 코드의 실패 응답은 SDK 필터가 `CommonApiResponse` 형식 예시 JSON으로 묶어 노출합니다.

### 스팀 인증 응답 코드 정비
- `SteamAuthException`을 `ExpectedException` 기반으로 전환하였습니다.
- `InvalidTicketException` → 401, `VacBanned`/`PublisherBanned`/`FamilySharingNotAllowed` → 403 으로 매핑하였습니다.
- `SteamApiException`은 업스트림(서버측) 장애이므로 `ExpectedException` 계층에서 분리하여 500 + 스택 로깅을 유지하였습니다.

## 검증

- 전체 156개 단위 테스트 통과하였습니다. (신규 `SteamAuthExceptionTests` 포함)
- `dotnet build` 성공하였습니다. (오류 0)
- Swagger 실문서 렌더링은 확인하지 못하였습니다. (앱 부팅 시 Postgres/Redis 연결이 필요)

## 영향

- 스팀 인증 실패 응답 코드가 500 → 401/403 으로 변경되어 클라이언트 계약에 영향이 있습니다.
- `SteamApiException`(업스트림 장애)의 500 및 회로 차단의 503 응답은 기존 동작을 유지하였습니다.

## 참고

- 0.4.0 SDK는 별도 `gamism-sdk` 리포지토리에서 배포되었습니다.
- 차단 예외는 `(ulong)` 생성자만 있어 SDK resolver가 타입 해석을 하지 못하므로 403은 명시 상태 코드로 문서화하였습니다. (후속으로 resolver 확장 검토 가능)
