### PR TITLE
[auth] Steam Web API 키 간접참조 제거

### DIFF
--- a/src/PushAndPull.Test/Global/Auth/SteamAuthTicketValidatorTests.cs
+++ b/src/PushAndPull.Test/Global/Auth/SteamAuthTicketValidatorTests.cs
@@ -191,10 +191,8 @@ public class SteamAuthTicketValidatorTests
                 ["Steam:AppId"] = "480",
             }).Build();
 
-            var ex = Record.Exception(() => new SteamAuthTicketValidator(
-                new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))), config));
-
-            Assert.Null(ex);
+            _ = new SteamAuthTicketValidator(
+                new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))), config);
         }
     }
 

--- a/src/PushAndPull.Test/Global/Auth/SteamAuthTicketValidatorTests.cs
+++ b/src/PushAndPull.Test/Global/Auth/SteamAuthTicketValidatorTests.cs
@@ -16,8 +16,7 @@ public class SteamAuthTicketValidatorTests
     private static IConfiguration BuildConfig() =>
         new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["Steam:WebApiKey"] = "key-name",
-            ["key-name"] = "secret-api-key",
+            ["Steam:WebApiKey"] = "secret-api-key",
             ["Steam:AppId"] = "480",
         }).Build();
 
@@ -181,28 +180,34 @@ public class SteamAuthTicketValidatorTests
         }
     }
 
+    public class WhenTheWebApiKeyIsConfigured
+    {
+        [Fact]
+        public void It_UsesTheWebApiKeyValueDirectly()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Steam:WebApiKey"] = "secret-api-key",
+                ["Steam:AppId"] = "480",
+            }).Build();
+
+            var ex = Record.Exception(() => new SteamAuthTicketValidator(
+                new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))), config));
+
+            Assert.Null(ex);
+        }
+    }
+
     public class WhenTheConfigurationIsInvalid
     {
         private static SteamAuthTicketValidator Build(IConfiguration config) =>
             new(new HttpClient(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK))), config);
 
         [Fact]
-        public void It_ThrowsWhenTheWebApiKeyNameIsMissing()
+        public void It_ThrowsWhenTheWebApiKeyIsMissing()
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Steam:AppId"] = "480",
-            }).Build();
-
-            Assert.Throws<ArgumentException>(() => Build(config));
-        }
-
-        [Fact]
-        public void It_ThrowsWhenTheApiKeySecretIsNotFound()
-        {
-            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Steam:WebApiKey"] = "key-name",
                 ["Steam:AppId"] = "480",
             }).Build();
 
@@ -214,8 +219,7 @@ public class SteamAuthTicketValidatorTests
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Steam:WebApiKey"] = "key-name",
-                ["key-name"] = "secret-api-key",
+                ["Steam:WebApiKey"] = "secret-api-key",
                 ["Steam:AppId"] = "not-an-int",
             }).Build();
 

--- a/src/PushAndPull.Test/Global/Auth/SteamCircuitBreakerTests.cs
+++ b/src/PushAndPull.Test/Global/Auth/SteamCircuitBreakerTests.cs
@@ -22,8 +22,7 @@ public class SteamCircuitBreakerTests
     private static IConfiguration BuildConfig(int minimumThroughput = 2, int timeoutSeconds = 5)
         => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["Steam:WebApiKey"] = "test-key-name",
-            ["test-key-name"] = "test-api-key",
+            ["Steam:WebApiKey"] = "test-api-key",
             ["Steam:AppId"] = "480",
             ["Steam:CircuitBreaker:FailureRatio"] = "0.5",
             ["Steam:CircuitBreaker:SamplingDurationSeconds"] = "2",

--- a/src/PushAndPull/Global/Auth/SteamAuthTicketValidator.cs
+++ b/src/PushAndPull/Global/Auth/SteamAuthTicketValidator.cs
@@ -24,10 +24,10 @@ public class SteamAuthTicketValidator : IAuthTicketValidator
         )
     {
         _httpClient = httpClient;
-        var apiKeySecretName = configuration["Steam:WebApiKey"]
-                             ?? throw new ArgumentException("STEAM_API_KEY_SECRET_NAME_REQUIRED");
-        _apiKey = configuration[apiKeySecretName]
-                  ?? throw new ArgumentException("STEAM_API_KEY_NOT_FOUND_IN_KEY_VAULT");
+        var apiKey = configuration["Steam:WebApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new ArgumentException("STEAM_API_KEY_REQUIRED");
+        _apiKey = apiKey;
 
         if (!int.TryParse(configuration["Steam:AppId"], out _appId))
             throw new ArgumentException("APPID_REQUIRED");

--- a/src/PushAndPull/appsettings.Production.json
+++ b/src/PushAndPull/appsettings.Production.json
@@ -6,7 +6,7 @@
     }
   },
   "Steam": {
-    "WebApiKey": "Steam-ApiKey",
+    "WebApiKey": "",
     "AppId": 0,
     "CircuitBreaker": {
       "FailureRatio": 0.5,


### PR DESCRIPTION
## 개요

`SteamAuthTicketValidator`가 `Steam:WebApiKey`를 시크릿 "이름"으로 간주해 한 번 더 조회하는 간접참조 구조였습니다. 그러나 배포 환경(compose)은 해당 설정에 실제 키 값을 직접 주입하므로, 로그인 시 2차 조회가 실패하여 `STEAM_API_KEY_NOT_FOUND_IN_KEY_VAULT` 예외로 500이 발생하였습니다. 키를 직접 읽도록 변경하였습니다.

## 변경 사항

- `SteamAuthTicketValidator` 생성자가 `Steam:WebApiKey`를 **실제 키 값으로 직접** 읽도록 변경하였습니다. 간접참조(`configuration[secretName]`)와 `STEAM_API_KEY_NOT_FOUND_IN_KEY_VAULT` 분기를 제거하였습니다.
- 값이 비어 있거나 누락된 경우 `STEAM_API_KEY_REQUIRED`로 명확히 실패하도록 하였습니다.
- `appsettings.Production.json`의 `Steam:WebApiKey`를 빈 값으로 정리하였습니다(실제 키는 배포 환경변수로 주입).
- 간접참조 전제의 테스트를 제거하고 직접 읽기 검증 테스트를 추가하였으며, 테스트 설정의 죽은 이중 항목을 정리하였습니다.

## 검증

- `dotnet test` 전체 163개 통과하였습니다.

## 영향

- `compose.yaml`은 이미 `Steam__WebApiKey=${STEAM_WEB_API_KEY}`로 실제 키를 직접 주입하므로 배포 설정 수정은 불필요합니다.
- stage·prod 모두 재배포 시 로그인 생성자에서 발생하던 500 오류가 해소됩니다.
- 단, 실제 로그인 성공은 `secrets.STEAM_API_KEY`(유효한 Steam Web API 키)와 `Steam:AppId`가 올바르게 주입되어야 가능합니다.

## 참고

- Azure Key Vault provider를 사용하지 않는 현재 구성 기준의 변경입니다. 향후 Key Vault 도입 시 이름 기반 간접참조를 다시 도입할 수 있습니다.
