### PR TITLE
[global] Gamism.SDK 0.5.0 버전 상향

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@
 | `Microsoft.Extensions.Caching.StackExchangeRedis` | 9.0.3 | `/stackexchange/stackexchange.redis` |
 | `Dapper` | 2.1.66 | `/dotnet/docs` |
 | `BCrypt.Net-Next` | 4.0.3 | — (no Context7 entry) |
-| `Gamism.SDK.Extensions.AspNetCore` | 0.3.2 | — (no Context7 entry) |
+| `Gamism.SDK.Extensions.AspNetCore` | 0.5.0 | — (no Context7 entry) |
 | `xunit` | 2.9.2 | `/xunit/xunit.net` |
 | `Moq` | 4.20.72 | — (no Context7 entry) |
 

--- a/src/PushAndPull/PushAndPull.csproj
+++ b/src/PushAndPull/PushAndPull.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
 <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Dapper" Version="2.1.66" />
-        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.4.0" />
+        <PackageReference Include="Gamism.SDK.Extensions.AspNetCore" Version="0.5.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.12" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## 개요

`Gamism.SDK.Extensions.AspNetCore` 패키지를 0.4.0에서 0.5.0으로 상향하였습니다. 신규 배포된 SDK 버전을 프로젝트에 반영합니다.

## 변경 사항

- `PushAndPull.csproj`의 `Gamism.SDK.Extensions.AspNetCore` 버전을 0.4.0 → 0.5.0으로 상향하였습니다.
- `CLAUDE.md` 기술 스택 표의 버전 표기를 실제 csproj와 동기화하여 0.5.0으로 갱신하였습니다.

## 검증

- 솔루션 빌드 성공하였습니다. (SDK 관련 오류·breaking change 없음, 기존 nullable 경고만 존재)
- 단위 테스트 163개 전부 통과하였습니다.

## 영향

- API 변경이나 breaking change 없이 패키지 버전만 상향되었습니다.
