### PR TITLE
[global] PR #60 리뷰 대응: 포트/프록시/닉네임 검증 수정

### DIFF
--- a/.github/workflows/pushandpull-prod-cd.yml
+++ b/.github/workflows/pushandpull-prod-cd.yml
@@ -97,10 +97,11 @@ jobs:
             set -euo pipefail
             mkdir -p ~/deploy
 
-            printf 'DB_CONNECTION_STRING=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\n' \
+            printf 'DB_CONNECTION_STRING=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\nCADDY_PROXY_IP=%s\n' \
               "${{ secrets.DB_CONNECTION_STRING }}" \
               "${{ secrets.STEAM_API_KEY }}" \
               "${{ secrets.STEAM_APP_ID }}" \
+              "${{ secrets.CADDY_PROXY_IP }}" \
               > ~/deploy/.env
 
             docker compose -f ~/deploy/compose.yaml -f ~/deploy/compose.prod.yaml --env-file ~/deploy/.env pull

--- a/.github/workflows/pushandpull-stage-cd.yml
+++ b/.github/workflows/pushandpull-stage-cd.yml
@@ -61,12 +61,13 @@ jobs:
             set -euo pipefail
             mkdir -p ~/deploy
 
-            printf 'POSTGRES_DB=%s\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\n' \
+            printf 'POSTGRES_DB=%s\nPOSTGRES_USER=%s\nPOSTGRES_PASSWORD=%s\nSTEAM_WEB_API_KEY=%s\nSTEAM_APP_ID=%s\nCADDY_PROXY_IP=%s\n' \
               "${{ secrets.STAGE_POSTGRES_DB }}" \
               "${{ secrets.STAGE_POSTGRES_USER }}" \
               "${{ secrets.STAGE_POSTGRES_PASSWORD }}" \
               "${{ secrets.STEAM_API_KEY }}" \
               "${{ secrets.STEAM_APP_ID }}" \
+              "${{ secrets.CADDY_PROXY_IP }}" \
               > ~/deploy/.env
 
             docker volume create pushandpull-stage-postgres-data

--- a/src/PushAndPull/Domain/Auth/Entity/User.cs
+++ b/src/PushAndPull/Domain/Auth/Entity/User.cs
@@ -11,7 +11,7 @@ public class User
 
     public User(ulong steamId, string nickname)
     {
-        if (string.IsNullOrWhiteSpace(nickname))
+        if (string.IsNullOrWhiteSpace(nickname) || nickname.Length > 32)
             throw new ArgumentException("INVALID_NICKNAME");
 
         SteamId = steamId;

--- a/src/PushAndPull/Global/Config/ForwardedHeadersConfig.cs
+++ b/src/PushAndPull/Global/Config/ForwardedHeadersConfig.cs
@@ -13,10 +13,15 @@ public static class ForwardedHeadersConfig
 
         services.Configure<ForwardedHeadersOptions>(options =>
         {
-            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
 
             if (!string.IsNullOrWhiteSpace(knownProxyIp))
-                options.KnownProxies.Add(IPAddress.Parse(knownProxyIp));
+            {
+                if (!IPAddress.TryParse(knownProxyIp, out var proxyIp))
+                    throw new InvalidOperationException($"ReverseProxy:KnownProxyIp is not a valid IP address: {knownProxyIp}");
+
+                options.KnownProxies.Add(proxyIp);
+            }
         });
 
         return services;

--- a/src/PushAndPull/Global/Config/ForwardedHeadersConfig.cs
+++ b/src/PushAndPull/Global/Config/ForwardedHeadersConfig.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace PushAndPull.Global.Config;
+
+public static class ForwardedHeadersConfig
+{
+    public static IServiceCollection AddForwardedHeaders(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var knownProxyIp = configuration["ReverseProxy:KnownProxyIp"];
+
+        services.Configure<ForwardedHeadersOptions>(options =>
+        {
+            options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+
+            if (!string.IsNullOrWhiteSpace(knownProxyIp))
+                options.KnownProxies.Add(IPAddress.Parse(knownProxyIp));
+        });
+
+        return services;
+    }
+}

--- a/src/PushAndPull/Program.cs
+++ b/src/PushAndPull/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddGlobalServices();
 builder.Services.AddAuthServices(builder.Configuration);
 builder.Services.AddRoomServices(builder.Configuration);
 builder.Services.AddRateLimit();
+builder.Services.AddForwardedHeaders(builder.Configuration);
 
 var app = builder.Build();
 
@@ -33,6 +34,7 @@ using (var scope = app.Services.CreateScope())
     await db.Database.MigrateAsync();
 }
 
+app.UseForwardedHeaders();
 app.UseRateLimiter();
 app.UseGamismSdk();
 app.MapControllers();

--- a/src/deploy/compose.prod.yaml
+++ b/src/deploy/compose.prod.yaml
@@ -7,7 +7,7 @@ services:
   pushandpull-server:
     container_name: pushandpull-server
     ports:
-      - "80:80"
+      - "80:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ConnectionStrings__Default=${DB_CONNECTION_STRING}

--- a/src/deploy/compose.prod.yaml
+++ b/src/deploy/compose.prod.yaml
@@ -11,3 +11,4 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - ConnectionStrings__Default=${DB_CONNECTION_STRING}
+      - ReverseProxy__KnownProxyIp=${CADDY_PROXY_IP}

--- a/src/deploy/compose.stage.yaml
+++ b/src/deploy/compose.stage.yaml
@@ -26,7 +26,7 @@ services:
     image: seanyee1227/pushandpull-server:stage
     container_name: pushandpull-stage-server
     ports:
-      - "80:80"
+      - "80:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Staging
       - ConnectionStrings__Default=Host=pushandpull-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password='${POSTGRES_PASSWORD}'

--- a/src/deploy/compose.stage.yaml
+++ b/src/deploy/compose.stage.yaml
@@ -30,6 +30,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Staging
       - ConnectionStrings__Default=Host=pushandpull-db;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password='${POSTGRES_PASSWORD}'
+      - ReverseProxy__KnownProxyIp=${CADDY_PROXY_IP}
     depends_on:
       pushandpull-db:
         condition: service_healthy

--- a/src/deploy/compose.yaml
+++ b/src/deploy/compose.yaml
@@ -10,7 +10,7 @@ services:
   pushandpull-server:
     image: seanyee1227/pushandpull-server:latest
     environment:
-      - ASPNETCORE_URLS=http://+:80
+      - ASPNETCORE_URLS=http://+:8080
       - Redis__ConnectionString=pushandpull-redis:6379,abortConnect=false
       - Steam__WebApiKey=${STEAM_WEB_API_KEY}
       - Steam__AppId=${STEAM_APP_ID}


### PR DESCRIPTION
## 개요

PR #60(v20260630.0) 배포 PR에 달린 Gemini 코드리뷰 중 타당한 지적 3건을 반영하였습니다. non-root 컨테이너의 포트 바인딩 오류, 리버스 프록시(Caddy) 뒤에서의 레이트리밋 IP 오인식, User 엔티티의 닉네임 길이 불변식 미검증을 수정하였습니다.

## 변경 사항

### 배포 포트 수정
- `prod.dockerfile`에서 non-root(`appuser`)로 전환되어 있어 컨테이너 내부에서 특권 포트(80)에 바인딩할 수 없는 문제를 수정하였습니다.
- `ASPNETCORE_URLS`를 `8080`으로, `compose.prod.yaml`/`compose.stage.yaml`의 포트 매핑을 `80:8080`으로 변경하였습니다.

### 리버스 프록시 뒤 레이트리밋 IP 인식
- Caddy가 앞단에서 트래픽을 대신 받아 전달하면 `RemoteIpAddress`가 항상 Caddy IP로 고정되어 전체 사용자가 레이트리밋을 공유하는 문제가 있었습니다.
- `ForwardedHeadersConfig`를 추가하고 `Program.cs`에 `UseForwardedHeaders()`를 등록하였습니다.
- 신뢰할 프록시 IP는 `ReverseProxy:KnownProxyIp` 설정으로 주입하며, `compose.prod.yaml`/`compose.stage.yaml`과 배포 워크플로에 `CADDY_PROXY_IP` 환경변수/시크릿 배선을 추가하였습니다. 값이 없으면 기존 기본 동작(루프백만 신뢰)을 유지합니다.

### User 엔티티 불변식 보강
- 엔티티 생성자가 스스로 불변식을 검증해야 한다는 프로젝트 규칙에 따라, `User` 생성자에서 닉네임 최대 길이(32자, DB 컬럼 제약과 동일) 검증을 추가하였습니다.

## 검증

- `dotnet build src/PushAndPull.sln` 통과 (경고만 존재, 기존과 동일)
- `dotnet test src/PushAndPull.sln`: 140개 통과. `RoomRepositoryTests`(Testcontainers) 23건은 이 환경에 Docker가 없어 실패한 것으로, 본 PR 변경과 무관한 환경 제약입니다.

## 영향

배포 환경에 GitHub Actions 시크릿 `CADDY_PROXY_IP`(Caddy 인스턴스가 앱 인스턴스에 접속할 때 사용하는 IP)를 추가해야 리버스 프록시 관련 수정이 실제로 동작합니다. 미설정 시에도 기존과 동일하게 안전하게 동작합니다.

## 참고

PR #60 Gemini 리뷰 대응입니다. 코멘트 7건 중 5건은 이 PR에서 수정하였고, 2건은 검토 후 반박(INVALID) 처리하여 PR #60에 답글로 남겼습니다.
- `SteamAuthTicketValidator`의 `JsonException` 처리는 이미 구현되어 있습니다.
- `RoomRepository`의 `ConstraintName` 체크는 현재 `room_code` 유니크 인덱스 하나만 존재하여 불필요한 방어 코드입니다.
