### PR TITLE
[room] 방 조회 엔드포인트 rate limiting 적용

### DIFF
--- a/src/PushAndPull/Domain/Room/Controller/RoomController.cs
+++ b/src/PushAndPull/Domain/Room/Controller/RoomController.cs
@@ -72,6 +72,7 @@ public class RoomController : ControllerBase
     [ApiDoc("방 조회", "roomCode로 단일 방 정보를 조회한다.")]
     [ApiError(typeof(RoomNotFoundException), "방을 찾을 수 없습니다.")]
     [HttpGet("{roomCode}")]
+    [EnableRateLimiting("read_room")]
     public async Task<CommonApiResponse<GetRoomResponse>> GetRoom(
         [FromRoute] string roomCode,
         CancellationToken ct
@@ -84,6 +85,7 @@ public class RoomController : ControllerBase
 
     [ApiDoc("방 목록 조회", "페이지네이션으로 공개된 방 목록을 조회한다.")]
     [HttpGet("all")]
+    [EnableRateLimiting("read_room")]
     public async Task<CommonApiResponse<GetAllRoomResponse>> GetAllRoom(
         [FromQuery] int page = 1,
         [FromQuery] int size = 20,

--- a/src/PushAndPull/Global/Config/RateLimitConfig.cs
+++ b/src/PushAndPull/Global/Config/RateLimitConfig.cs
@@ -38,6 +38,16 @@ public static class RateLimitConfig
                         Window = TimeSpan.FromMinutes(1)
                     }));
 
+            // 인증 없이 열려 있는 방 조회 엔드포인트의 열거/스크래핑을 제한한다.
+            options.AddPolicy("read_room", httpContext =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: GetIpKey(httpContext),
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = 60,
+                        Window = TimeSpan.FromMinutes(1)
+                    }));
+
             options.OnRejected = async (context, token) =>
             {
                 context.HttpContext.Response.StatusCode = 429;

--- a/src/PushAndPull/appsettings.json
+++ b/src/PushAndPull/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## 개요

인증 없이 열려 있는 방 조회 엔드포인트에 IP 기반 rate limiting을 적용하여 방 목록 열거 및 스크래핑을 제한하였습니다. 아울러 HttpClient 요청 로그 노이즈를 줄이도록 로그 레벨을 조정하였습니다.

## 변경 사항

- `RateLimitConfig`에 `read_room` 정책을 추가하였습니다. IP 단위 Fixed Window 방식으로 분당 60회로 제한하였습니다.
- `RoomController`의 방 단일 조회(`GET {roomCode}`)와 방 목록 조회(`GET all`) 엔드포인트에 `[EnableRateLimiting("read_room")]`를 적용하였습니다.
- `appsettings.json`의 로깅 설정에 `System.Net.Http.HttpClient` 레벨을 `Warning`으로 추가하여 HttpClient 요청 로그를 억제하였습니다.

## 검증

- 로컬 빌드로 컴파일 정상 확인하였습니다.

## 영향

- 동일 IP에서 방 조회 요청이 분당 60회를 초과하면 429 응답을 반환하게 되었습니다. 정상 사용자 트래픽 범위에는 영향이 없도록 여유 있게 설정하였습니다.
- 로깅 변경으로 HttpClient 관련 Information 로그가 더 이상 출력되지 않습니다.
